### PR TITLE
Update output argument help text

### DIFF
--- a/src/telegram_download_chat/cli.py
+++ b/src/telegram_download_chat/cli.py
@@ -53,7 +53,7 @@ def parse_args():
     )
     parser.add_argument(
         '-o', '--output',
-        help="Output file path (default: chat_history_<chat_id>.json)",
+        help="Output file path (default: <chat_name>.json)",
         default=None
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- adjust `--output` help message to explain default output path

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684161cd0478832c89a7c5ccd70e3df6