### PR TITLE
Add recipient names to TXT output

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ users_map:
   789012: "Bob Johnson"
 ```
 
+### Chat Mapping
+Use `chats_map` to provide friendly names for chat IDs when saving TXT output:
+
+```yaml
+chats_map:
+  100123456: "MyGroup"
+```
+
 ### Subchat Extraction
 Extract conversations from specific threads or reply chains:
 
@@ -329,13 +337,13 @@ A human-readable version of the chat with:
 ### Example Output Structure
 
 ```
-2025-05-25 10:30:15 Alice:
-Hello everyone! 
+2025-05-25 10:30:15 Alice -> MyGroup:
+Hello everyone!
 
-2025-05-25 10:31:22 Bob (replying to Alice):
+2025-05-25 10:31:22 Bob -> MyGroup (replying to Alice):
 Hi Alice! How are you?
 
-2025-05-25 10:32:45 Charlie:
+2025-05-25 10:32:45 Charlie -> MyGroup:
 Welcome to the group!
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ settings:
   log_file: app.log        # Path to log file (relative to app dir or absolute)
 
 # Map user IDs to display names for text exports
+# Names for users and bots are automatically fetched and stored here
 users_map:
   123456: "Alice"
   789012: "Bob"
@@ -225,7 +226,7 @@ The tool will process the archive and generate both JSON and TXT files with the 
 If the download is interrupted, you can simply run the same command again to resume from where it left off. The tool automatically saves progress to a temporary file.
 
 ### User Mapping
-Edit the `users_map` section in your config file to map Telegram user IDs to display names in the TXT output:
+Display names for users and bots are collected automatically. You can override them in the `users_map` section:
 
 ```yaml
 users_map:
@@ -234,7 +235,7 @@ users_map:
 ```
 
 ### Chat Mapping
-Full chat titles are fetched automatically. Use `chats_map` only if you want to override them:
+Titles for group and channel chats are fetched automatically. Use `chats_map` only if you want to override them:
 
 ```yaml
 chats_map:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ users_map:
 ```
 
 ### Chat Mapping
-Use `chats_map` to provide friendly names for chat IDs when saving TXT output:
+Full chat titles are fetched automatically. Use `chats_map` only if you want to override them:
 
 ```yaml
 chats_map:

--- a/config.example.yml
+++ b/config.example.yml
@@ -24,11 +24,11 @@ settings:
   # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   log_level: INFO
 
-# User mapping for TXT export
+# Optional mapping for overriding user full names
 users_map:
   123456: "Alice"
   789012: "Bob"
 
-# Chat mapping for TXT export
+# Optional mapping for overriding chat titles
 chats_map:
   100123456: "MyGroup"

--- a/config.example.yml
+++ b/config.example.yml
@@ -28,3 +28,7 @@ settings:
 users_map:
   123456: "Alice"
   789012: "Bob"
+
+# Chat mapping for TXT export
+chats_map:
+  100123456: "MyGroup"

--- a/config.example.yml
+++ b/config.example.yml
@@ -24,11 +24,13 @@ settings:
   # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   log_level: INFO
 
-# Optional mapping for overriding user full names
+# Optional mapping for overriding user and bot full names
+# Names are fetched automatically and stored here
 users_map:
   123456: "Alice"
   789012: "Bob"
 
-# Optional mapping for overriding chat titles
+# Optional mapping for overriding group or channel titles
+# Titles for groups and channels are fetched automatically
 chats_map:
   100123456: "MyGroup"


### PR DESCRIPTION
## Summary
- include a new `chats_map` section in example config
- document chat mapping in README and show updated sample
- store chat names and recipient IDs in downloader
- include recipient name in save_messages_as_txt text output

## Testing
- `pytest -q`
- `mypy src/` *(fails: missing stubs and typing issues)*

------
https://chatgpt.com/codex/tasks/task_e_684163769e44832cbd5323d919fbdeeb