### PR TITLE
Add reply context and sort option for TXT exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ telegram-download-chat --show-config
 ### Command Line Options
 
 ```
-usage: telegram-download-chat [-h] [-o OUTPUT] [--limit LIMIT] [--until DATE] [--subchat SUBCHAT] 
-                            [--subchat-name NAME] [--user USER] [--config CONFIG] [--debug] 
-                            [--show-config] [-v]
+usage: telegram-download-chat [-h] [-o OUTPUT] [--limit LIMIT] [--until DATE] [--subchat SUBCHAT]
+                            [--subchat-name NAME] [--user USER] [--config CONFIG] [--debug]
+                            [--sort {asc,desc}] [--show-config] [-v]
                             [chat]
 
 Download Telegram chat history to JSON and TXT formats.
@@ -193,6 +193,7 @@ options:
   --user USER           Filter messages by sender ID
   -c, --config CONFIG   Path to config file
   --debug               Enable debug logging
+  --sort {asc,desc}     Sort messages by date (default: desc)
   --show-config         Show config file location and exit
   -v, --version         Show program's version number and exit
 ```

--- a/src/telegram_download_chat/cli.py
+++ b/src/telegram_download_chat/cli.py
@@ -3,11 +3,8 @@
 
 # Suppress pkg_resources deprecation warning
 import warnings
-warnings.filterwarnings(
-    'ignore',
-    message='pkg_resources is deprecated',
-    category=DeprecationWarning
-)
+
+warnings.filterwarnings("ignore", message="pkg_resources is deprecated", category=DeprecationWarning)
 
 import argparse
 import asyncio
@@ -15,16 +12,21 @@ import json
 import logging
 import signal
 import sys
-from pathlib import Path
-from typing import Dict, Any, List
 import traceback
+from pathlib import Path
+from typing import Any, Dict, List
 
 from telegram_download_chat import __version__
 from telegram_download_chat.core import TelegramChatDownloader
-from telegram_download_chat.paths import get_default_config_path, get_downloads_dir, get_relative_to_downloads_dir
+from telegram_download_chat.paths import (
+    get_default_config_path,
+    get_downloads_dir,
+    get_relative_to_downloads_dir,
+)
 
 # Global downloader instance for signal handling
 _downloader_instance = None
+
 
 def signal_handler(sig, frame):
     """Handle termination signals for graceful shutdown."""
@@ -35,133 +37,93 @@ def signal_handler(sig, frame):
     else:
         sys.exit(0)
 
+
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
 
+
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Download Telegram chat history to JSON"
-    )
-    
+    parser = argparse.ArgumentParser(description="Download Telegram chat history to JSON")
+
+    parser.add_argument("chat", nargs="?", help="Chat identifier (username, phone number, or chat ID)")
+    parser.add_argument("-o", "--output", help="Output file path (default: <chat_name>.json)", default=None)
     parser.add_argument(
-        'chat',
-        nargs="?",
-        help="Chat identifier (username, phone number, or chat ID)"
+        "-l", "--limit", type=int, default=0, help="Maximum number of messages to download (default: 0 - no limit)"
     )
+    parser.add_argument("-c", "--config", default=None, help="Path to config file (default: OS-specific location)")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument(
-        '-o', '--output',
-        help="Output file path (default: <chat_name>.json)",
-        default=None
+        "--show-config", action="store_true", help="Show the current configuration file location and exit"
     )
     parser.add_argument(
-        '-l', '--limit',
-        type=int,
-        default=0,
-        help="Maximum number of messages to download (default: 0 - no limit)"
+        "--subchat", type=str, help="Filter messages for txt by subchat id or URL (only for JSON to TXT conversion)"
     )
     parser.add_argument(
-        '-c', '--config',
-        default=None,
-        help="Path to config file (default: OS-specific location)"
+        "--subchat-name", type=str, help="Name for the subchat directory (default: subchat_<subchat_id>)"
     )
-    parser.add_argument(
-        '--debug',
-        action='store_true',
-        help="Enable debug logging"
-    )
-    parser.add_argument(
-        '--show-config',
-        action='store_true',
-        help="Show the current configuration file location and exit"
-    )
-    parser.add_argument(
-        '--subchat',
-        type=str,
-        help="Filter messages for txt by subchat id or URL (only for JSON to TXT conversion)"
-    )
-    parser.add_argument(
-        '--subchat-name',
-        type=str,
-        help="Name for the subchat directory (default: subchat_<subchat_id>)"
-    )
-    parser.add_argument(
-        '--user',
-        type=str,
-        help="Filter messages by sender ID (e.g., 12345 or user12345)"
-    )
-    parser.add_argument(
-        '--until',
-        type=str,
-        help="Only download messages until this date (format: YYYY-MM-DD)"
-    )
-    parser.add_argument(
-        '--split',
-        choices=['month', 'year'],
-        help="Split output files by month or year"
-    )
-    parser.add_argument(
-        '-v', '--version',
-        action='version',
-        version=f'%(prog)s {__version__}'
-    )
-    
+    parser.add_argument("--user", type=str, help="Filter messages by sender ID (e.g., 12345 or user12345)")
+    parser.add_argument("--until", type=str, help="Only download messages until this date (format: YYYY-MM-DD)")
+    parser.add_argument("--split", choices=["month", "year"], help="Split output files by month or year")
+    parser.add_argument("--sort", choices=["asc", "desc"], default="desc", help="Sort messages by date (default: desc)")
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
+
     return parser.parse_args()
 
 
 def split_messages_by_date(messages: List[Dict[str, Any]], split_by: str) -> Dict[str, List[Dict[str, Any]]]:
     """Split messages by month or year based on message date.
-    
+
     Args:
         messages: List of message dictionaries
         split_by: Either 'month' or 'year' to determine how to split
-        
+
     Returns:
         Dictionary with keys as date strings (YYYY-MM or YYYY) and values as message lists
     """
     from datetime import datetime
-    
+
     split_messages = {}
-    
+
     for msg in messages:
-        if not msg.get('date'):
+        if not msg.get("date"):
             continue
-            
+
         try:
             # Parse the date string to datetime object
-            dt = datetime.strptime(msg['date'].split('.')[0], '%Y-%m-%dT%H:%M:%S')
-            
+            dt = datetime.strptime(msg["date"].split(".")[0], "%Y-%m-%dT%H:%M:%S")
+
             # Create the key based on split type
-            if split_by == 'month':
-                key = dt.strftime('%Y-%m')  # YYYY-MM format
+            if split_by == "month":
+                key = dt.strftime("%Y-%m")  # YYYY-MM format
             else:  # year
-                key = dt.strftime('%Y')  # YYYY format
-                
+                key = dt.strftime("%Y")  # YYYY format
+
             # Add message to the appropriate group
             if key not in split_messages:
                 split_messages[key] = []
             split_messages[key].append(msg)
-            
+
         except (ValueError, AttributeError) as e:
             continue
-            
+
     return split_messages
 
 
 def filter_messages_by_subchat(messages: List[Dict[str, Any]], subchat_id: str) -> List[Dict[str, Any]]:
     """Filter messages by reply_to_msg_id or reply_to_top_id.
-    
+
     Args:
         messages: List of message dictionaries
         subchat_id: Message ID to filter by (as string)
-        
+
     Returns:
         Filtered list of messages
     """
     # Convert subchat_id to int for comparison, or extract from URL
-    if subchat_id.startswith('https://t.me/c/'):
+    if subchat_id.startswith("https://t.me/c/"):
         # Extract message ID from URL format: https://t.me/c/CHANNEL_ID/MESSAGE_ID
-        parts = subchat_id.strip('/').split('/')
+        parts = subchat_id.strip("/").split("/")
         if len(parts) >= 3:
             try:
                 target_id = int(parts[-1])  # Take the last part as message ID
@@ -174,66 +136,70 @@ def filter_messages_by_subchat(messages: List[Dict[str, Any]], subchat_id: str) 
             target_id = int(subchat_id)
         except ValueError:
             raise ValueError(f"Invalid message ID format: {subchat_id}")
-    
+
     filtered = []
     for msg in messages:
-        reply_to = msg.get('reply_to')
+        reply_to = msg.get("reply_to")
         if not reply_to:
             continue
-            
+
         # Check both reply_to_msg_id and reply_to_top_id
-        if (str(reply_to.get('reply_to_msg_id')) == str(target_id) or
-            str(reply_to.get('reply_to_top_id')) == str(target_id)):
+        if str(reply_to.get("reply_to_msg_id")) == str(target_id) or str(reply_to.get("reply_to_top_id")) == str(
+            target_id
+        ):
             filtered.append(msg)
-    
+
     return filtered
 
 
 async def _run_with_status(task_coro: Any, logger: logging.Logger, message: str = None):
     """Run a coroutine and show a status message if it takes more than 2 seconds.
-    
+
     The function will wait for either the task to complete or 2 seconds to elapse,
     whichever comes first. If the task is still running after 2 seconds, a status
     message will be shown.
     """
     task = asyncio.create_task(task_coro)
-    
+
     try:
         # Wait for either the task to complete or 2 seconds to elapse
-        done, pending = await asyncio.wait(
-            [task],
-            timeout=2.0,
-            return_when=asyncio.FIRST_COMPLETED
-        )
-        
+        done, pending = await asyncio.wait([task], timeout=2.0, return_when=asyncio.FIRST_COMPLETED)
+
         # If task is still pending after timeout, show status message
         if pending and not message:
             message = "Saving messages..."
             logger.info(message)
-            
+
     except asyncio.CancelledError:
         task.cancel()
         raise
-        
+
     return await task
 
 
-async def save_messages_with_status(downloader: TelegramChatDownloader, messages: List[Any], output_file: str) -> None:
-    return await _run_with_status(downloader.save_messages(messages, output_file), downloader.logger)
+async def save_messages_with_status(
+    downloader: TelegramChatDownloader, messages: List[Any], output_file: str, sort_order: str = "desc"
+) -> None:
+    return await _run_with_status(
+        downloader.save_messages(messages, output_file, sort_order=sort_order), downloader.logger
+    )
 
 
-async def save_txt_with_status(downloader: TelegramChatDownloader, messages: List[Any], txt_file: Path) -> int:
-    return await _run_with_status(downloader.save_messages_as_txt(messages, txt_file), downloader.logger)
+async def save_txt_with_status(
+    downloader: TelegramChatDownloader, messages: List[Any], txt_file: Path, sort_order: str = "desc"
+) -> int:
+    return await _run_with_status(downloader.save_messages_as_txt(messages, txt_file, sort_order), downloader.logger)
+
 
 async def async_main():
     """Main async function."""
     global _downloader_instance
     args = parse_args()
-    
+
     # Initialize downloader with config
     downloader = TelegramChatDownloader(config_path=args.config)
     _downloader_instance = downloader
-    
+
     try:
         # Show config path and exit if requested
         if args.show_config:
@@ -242,23 +208,23 @@ async def async_main():
             if config_path.exists():
                 downloader.logger.info("\nCurrent configuration:")
                 try:
-                    with open(config_path, 'r', encoding='utf-8') as f:
+                    with open(config_path, "r", encoding="utf-8") as f:
                         downloader.logger.info(f.read())
                 except Exception as e:
                     downloader.logger.error(f"\nError reading config file: {e}")
             else:
                 downloader.logger.info("\nConfiguration file does not exist yet. It will be created on first run.")
             return 0
-        
+
         # Set debug log level if requested
         if args.debug:
             downloader.logger.setLevel(logging.DEBUG)
             downloader.logger.debug("Debug logging enabled")
-        
+
         if not args.chat:
             downloader.logger.error("Chat identifier is required")
             return 1
-            
+
         # Connect to Telegram
         try:
             await downloader.connect()
@@ -270,20 +236,21 @@ async def async_main():
 
         # Set up stop file for inter-process communication using fixed name
         import tempfile
+
         stop_file = Path(tempfile.gettempdir()) / "telegram_download_stop.tmp"
         downloader.set_stop_file(str(stop_file))
 
         # Get downloads directory from config
-        downloads_dir = Path(downloader.config.get('settings', {}).get('save_path', get_downloads_dir()))
+        downloads_dir = Path(downloader.config.get("settings", {}).get("save_path", get_downloads_dir()))
         downloads_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Handle JSON conversion mode if --subchat is provided without --json
-        if args.subchat and not args.output and not args.chat.endswith('.json'):
+        if args.subchat and not args.output and not args.chat.endswith(".json"):
             downloader.logger.error("--subchat requires an existing JSON file as input")
             return 1
-            
+
         # Check if we're in JSON conversion mode
-        if args.chat.endswith('.json'):
+        if args.chat.endswith(".json"):
             json_path = Path(args.chat)
 
             if not json_path.exists() and not json_path.is_absolute():
@@ -292,71 +259,73 @@ async def async_main():
             if not json_path.exists():
                 downloader.logger.error(f"File not found: {json_path}")
                 return 1
-                
+
             downloader.logger.debug(f"Loading messages from JSON file: {json_path}")
-                
-            with open(json_path, 'r', encoding='utf-8') as f:
+
+            with open(json_path, "r", encoding="utf-8") as f:
                 messages = json.load(f)
-                
+
             # Check if messages is a dictionary with 'about' and 'chats' keys
-            if isinstance(messages, dict) and 'about' in messages and 'chats' in messages:
+            if isinstance(messages, dict) and "about" in messages and "chats" in messages:
                 messages = downloader.convert_archive_to_messages(messages, user_filter=args.user)
-                
-            txt_path = Path(json_path).with_suffix('.txt')
-            
+
+            txt_path = Path(json_path).with_suffix(".txt")
+
             # If user filter is specified, add it to the filename
             if args.user:
-                user_id = args.user.replace('user', '') if args.user.startswith('user') else args.user
+                user_id = args.user.replace("user", "") if args.user.startswith("user") else args.user
                 txt_path = txt_path.with_stem(f"{txt_path.stem}_user_{user_id}")
 
             # Apply subchat filter if specified
             if args.subchat:
                 messages = filter_messages_by_subchat(messages, args.subchat)
                 # Use subchat_name directly in filename
-                txt_path = downloads_dir / f"{args.subchat_name or f'{txt_path.stem}_subchat_{args.subchat}'}{txt_path.suffix}"
+                txt_path = (
+                    downloads_dir / f"{args.subchat_name or f'{txt_path.stem}_subchat_{args.subchat}'}{txt_path.suffix}"
+                )
                 downloader.logger.info(f"Filtered to {len(messages)} messages in subchat {args.subchat}")
-            
+
             # Handle message splitting if requested
             if args.split:
                 split_messages = split_messages_by_date(messages, args.split)
                 if not split_messages:
                     downloader.logger.warning("No messages with valid dates found for splitting")
-                    saved = await save_txt_with_status(downloader, messages, txt_path)
+                    saved = await save_txt_with_status(downloader, messages, txt_path, args.sort)
                     saved_relative = get_relative_to_downloads_dir(txt_path)
                     downloader.logger.info(f"Saved {saved} messages to {saved_relative}")
                 else:
                     # Save each group to a separate file
                     base_name = txt_path.stem
                     ext = txt_path.suffix
-                    
+
                     for date_key, msgs in split_messages.items():
                         split_file = txt_path.with_name(f"{base_name}_{date_key}{ext}")
-                        saved = await save_txt_with_status(downloader, msgs, split_file)
+                        saved = await save_txt_with_status(downloader, msgs, split_file, args.sort)
                         saved_relative = get_relative_to_downloads_dir(split_file)
                         downloader.logger.info(f"Saved {saved} messages to {saved_relative}")
-                    
+
                     downloader.logger.info(f"Saved {len(split_messages)} split files in {txt_path.parent}")
             else:
-                saved = await save_txt_with_status(downloader, messages, txt_path)
+                saved = await save_txt_with_status(downloader, messages, txt_path, args.sort)
                 saved_relative = get_relative_to_downloads_dir(txt_path)
                 downloader.logger.info(f"Saved {saved} messages to {saved_relative}")
-                
+
             downloader.logger.debug("Conversion completed successfully")
             return 0
-            
+
         # Normal chat download mode
         downloader.logger.debug("Connecting to Telegram...")
         await downloader.connect()
-        
+
         safe_chat_name = await downloader.get_entity_name(args.chat)
         if not safe_chat_name:
             downloader.logger.error(f"Failed to get entity name for chat: {args.chat}")
             return 1
 
         # Get downloads directory from config
-        downloads_dir = Path(downloader.config.get('settings', {}).get('save_path', get_downloads_dir()))
+        downloads_dir = Path(downloader.config.get("settings", {}).get("save_path", get_downloads_dir()))
         downloads_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Determine output file
         output_file = args.output
         if not output_file:
@@ -366,63 +335,63 @@ async def async_main():
             except Exception as e:
                 downloader.logger.warning(f"Could not get entity name: {e}, using basic sanitization")
                 safe_chat_name = "".join(c if c.isalnum() else "_" for c in args.chat)
-            
+
             output_file = str(downloads_dir / f"{safe_chat_name}.json")
-            
+
             if args.subchat:
                 output_file = str(Path(output_file).with_stem(f"{Path(output_file).stem}_subchat_{args.subchat}"))
-        
+
         # Download messages
         download_kwargs = {
-            'chat_id': args.chat,
-            'request_limit': args.limit if args.limit > 0 else 100,
-            'total_limit': args.limit if args.limit > 0 else 0,
-            'output_file': output_file,
-            'silent': False
+            "chat_id": args.chat,
+            "request_limit": args.limit if args.limit > 0 else 100,
+            "total_limit": args.limit if args.limit > 0 else 0,
+            "output_file": output_file,
+            "silent": False,
         }
         if args.until:
-            download_kwargs['until_date'] = args.until
-            
+            download_kwargs["until_date"] = args.until
+
         messages = await downloader.download_chat(**download_kwargs)
-        
+
         downloader.logger.debug(f"Downloaded {len(messages)} messages")
-        
+
         # Apply subchat filter if specified
         if args.subchat:
             messages = filter_messages_by_subchat(messages, args.subchat)
             downloader.logger.info(f"Filtered to {len(messages)} messages in subchat {args.subchat}")
-            
+
         if not messages:
             downloader.logger.warning("No messages to save")
             return 0
-        
+
         try:
             if args.split:
                 # Split messages by date
                 split_messages = split_messages_by_date(messages, args.split)
-                
+
                 if not split_messages:
                     downloader.logger.warning("No messages with valid dates found for splitting")
-                    await save_messages_with_status(downloader, messages, output_file)
+                    await save_messages_with_status(downloader, messages, output_file, args.sort)
                 else:
                     # Save each group to a separate file
                     output_path = Path(output_file)
                     base_name = output_path.stem
                     ext = output_path.suffix
-                    
+
                     for date_key, msgs in split_messages.items():
                         split_file = output_path.with_name(f"{base_name}_{date_key}{ext}")
-                        await save_messages_with_status(downloader, msgs, str(split_file))
+                        await save_messages_with_status(downloader, msgs, str(split_file), args.sort)
                         downloader.logger.info(f"Saved {len(msgs)} messages to {split_file}")
-                    
+
                     downloader.logger.info(f"Saved {len(split_messages)} split files in {output_path.parent}")
             else:
-                await save_messages_with_status(downloader, messages, output_file)
-                
+                await save_messages_with_status(downloader, messages, output_file, args.sort)
+
         except Exception as e:
             downloader.logger.error(f"Failed to save messages: {e}", exc_info=args.debug)
             return 1
-        
+
     except Exception as e:
         downloader.logger.error(f"An error occurred: {e}", exc_info=args.debug)
         downloader.logger.error(traceback.format_exc())
@@ -436,12 +405,14 @@ async def async_main():
         except Exception:
             pass
 
+
 def main() -> int:
     """Main entry point."""
     # Support GUI mode: `telegram-download-chat gui`
-    if (len(sys.argv) >= 2 and sys.argv[1] == 'gui') or len(sys.argv) == 1:
+    if (len(sys.argv) >= 2 and sys.argv[1] == "gui") or len(sys.argv) == 1:
         try:
             from telegram_download_chat.gui.main import main as gui_main
+
             gui_main()
             return 0
         except ImportError as e:
@@ -452,7 +423,7 @@ def main() -> int:
             print(f"Error starting GUI: {e}")
             print(e)
             return 1
-            
+
     try:
         return asyncio.run(async_main())
     except KeyboardInterrupt:

--- a/src/telegram_download_chat/core.py
+++ b/src/telegram_download_chat/core.py
@@ -10,18 +10,38 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
+
 import yaml
 from telethon import TelegramClient
+from telethon.errors import ChatIdInvalidError
 from telethon.tl.custom import Message
-from telethon.tl.types import PeerUser, PeerChat, PeerChannel, User, Chat, Channel, TypePeer, Message, MessageService
 from telethon.tl.functions.channels import GetFullChannelRequest
 from telethon.tl.functions.messages import GetFullChatRequest
-from telethon.errors import ChatIdInvalidError
-from telegram_download_chat.paths import get_default_config, get_default_config_path, ensure_app_dirs, get_app_dir, get_downloads_dir, get_relative_to_downloads_dir
+from telethon.tl.types import (
+    Channel,
+    Chat,
+    Message,
+    MessageService,
+    PeerChannel,
+    PeerChat,
+    PeerUser,
+    TypePeer,
+    User,
+)
+
+from telegram_download_chat.paths import (
+    ensure_app_dirs,
+    get_app_dir,
+    get_default_config,
+    get_default_config_path,
+    get_downloads_dir,
+    get_relative_to_downloads_dir,
+)
+
 
 class TelegramChatDownloader:
     """Main class for downloading Telegram chat history."""
-    
+
     def __init__(self, config_path: Optional[str] = None):
         """Initialize the downloader with optional config path."""
         self.config_path = config_path
@@ -35,78 +55,78 @@ class TelegramChatDownloader:
         self._fetched_chatnames_count = 0  # Counter for fetched chat names
         self._self_id: Optional[int] = None  # ID of the current user
         self._self_name: Optional[str] = None  # Full name of the current user
-    
+
     def _load_config(self) -> Dict[str, Any]:
         """
         Load configuration from YAML file or create default if not exists.
-        
+
         Returns:
             dict: Loaded or default configuration
         """
         # Ensure app directories exist
         ensure_app_dirs()
-        
+
         # Use default config path if none provided
         if not self.config_path:
             self.config_path = str(get_default_config_path())
-        
+
         config_path = Path(self.config_path)
         default_config = get_default_config()
-        
+
         # Create default config if it doesn't exist
         if not config_path.exists():
             try:
                 config_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(config_path, 'w', encoding='utf-8') as f:
+                with open(config_path, "w", encoding="utf-8") as f:
                     yaml.safe_dump(default_config, f, default_flow_style=False)
                 logging.info(f"Created default config at {config_path}")
-                print("\n" + "="*80)
+                print("\n" + "=" * 80)
                 print("First run configuration:")
                 print("1. Go to https://my.telegram.org/apps")
                 print("2. Create a new application")
                 print("3. Copy API ID and API Hash")
                 print(f"4. Edit the config file at: {config_path}")
                 print("5. Replace 'YOUR_API_ID' and 'YOUR_API_HASH' with your credentials")
-                print("="*80 + "\n")
+                print("=" * 80 + "\n")
                 return default_config
             except Exception as e:
                 logging.error(f"Failed to create default config: {e}")
                 return default_config
-        
+
         # Load existing config
         try:
-            with open(config_path, 'r', encoding='utf-8') as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 loaded_config = yaml.safe_load(f) or {}
-                
+
             # Handle old config format (api_id/api_hash at root level)
-            if 'api_id' in loaded_config or 'api_hash' in loaded_config:
+            if "api_id" in loaded_config or "api_hash" in loaded_config:
                 # Migrate old format to new format
-                if 'settings' not in loaded_config:
-                    loaded_config['settings'] = {}
-                if 'api_id' in loaded_config:
-                    loaded_config['settings']['api_id'] = loaded_config.pop('api_id')
-                if 'api_hash' in loaded_config:
-                    loaded_config['settings']['api_hash'] = loaded_config.pop('api_hash')
-                
+                if "settings" not in loaded_config:
+                    loaded_config["settings"] = {}
+                if "api_id" in loaded_config:
+                    loaded_config["settings"]["api_id"] = loaded_config.pop("api_id")
+                if "api_hash" in loaded_config:
+                    loaded_config["settings"]["api_hash"] = loaded_config.pop("api_hash")
+
                 # Save the updated config
-                with open(config_path, 'w', encoding='utf-8') as f:
+                with open(config_path, "w", encoding="utf-8") as f:
                     yaml.safe_dump(loaded_config, f, default_flow_style=False)
-                
+
             # Merge with defaults to ensure all required keys exist
             return self._merge_configs(default_config, loaded_config)
-            
+
         except yaml.YAMLError as e:
             logging.error(f"Error loading config from {config_path}: {e}")
             return default_config
-    
+
     def _merge_configs(self, default: Dict[str, Any], custom: Dict[str, Any]) -> Dict[str, Any]:
         """
         Recursively merge two configuration dictionaries.
-        
+
         Args:
             default: Default configuration
             custom: Custom configuration to merge over defaults
-            
+
         Returns:
             dict: Merged configuration
         """
@@ -120,79 +140,84 @@ class TelegramChatDownloader:
 
     def _setup_logging(self) -> None:
         """Configure logging based on config."""
-        log_level = self.config.get('settings', {}).get('log_level', 'INFO')
-        log_file = self.config.get('settings', {}).get('log_file', get_app_dir()/'app.log')
-        
+        log_level = self.config.get("settings", {}).get("log_level", "INFO")
+        log_file = self.config.get("settings", {}).get("log_file", get_app_dir() / "app.log")
+
         # Ensure log directory exists
         if log_file:
             log_path = Path(log_file)
             log_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Configure root logger first
         root_logger = logging.getLogger()
         root_logger.setLevel(logging.WARNING)  # Set default level to WARNING
-        
+
         # Clear any existing handlers
         for handler in root_logger.handlers[:]:
             root_logger.removeHandler(handler)
-        
+
         # Configure our logger
-        self.logger = logging.getLogger('telegram_download_chat')
+        self.logger = logging.getLogger("telegram_download_chat")
         self.logger.setLevel(getattr(logging, log_level.upper()))
-        
+
         # Create formatter
-        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-        
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+
         # Add file handler if log file is specified
         if log_file:
-            file_handler = logging.FileHandler(log_file, encoding='utf-8')
+            file_handler = logging.FileHandler(log_file, encoding="utf-8")
             file_handler.setFormatter(formatter)
             self.logger.addHandler(file_handler)
-        
+
         # Add console handler
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         self.logger.addHandler(console_handler)
-        
+
         # Suppress Telethon's debug and info messages
-        telethon_logger = logging.getLogger('telethon')
+        telethon_logger = logging.getLogger("telethon")
         telethon_logger.setLevel(logging.WARNING)
-        
+
         # Suppress asyncio debug messages
-        asyncio_logger = logging.getLogger('asyncio')
+        asyncio_logger = logging.getLogger("asyncio")
         asyncio_logger.setLevel(logging.WARNING)
-    
+
     async def connect(self, phone: str = None, code: str = None, password: str = None):
         """Connect to Telegram using the configured API credentials."""
-        from telethon.errors import SessionPasswordNeededError, PhoneCodeInvalidError, ApiIdInvalidError, PhoneNumberInvalidError
-        
+        from telethon.errors import (
+            ApiIdInvalidError,
+            PhoneCodeInvalidError,
+            PhoneNumberInvalidError,
+            SessionPasswordNeededError,
+        )
+
         if self.client and await self.client.is_user_authorized():
             return
 
         # Get API credentials from settings section
-        settings = self.config.get('settings', {})
-        api_id = settings.get('api_id')
-        api_hash = settings.get('api_hash')
+        settings = self.config.get("settings", {})
+        api_id = settings.get("api_id")
+        api_hash = settings.get("api_hash")
         # Only fall back to the value stored in the config if the caller didn't
         # supply a phone number explicitly. Previously we would always override
         # the passed ``phone`` argument which meant the login flow could never
         # start when the config didn't contain a phone value.
         if phone is None:
-            phone = settings.get('phone')
-        
+            phone = settings.get("phone")
+
         # Default values
-        session_file = str(get_app_dir() / 'session.session')
-        request_delay = settings.get('request_delay', 1)
-        request_retries = settings.get('max_retries', 5)
-        
+        session_file = str(get_app_dir() / "session.session")
+        request_delay = settings.get("request_delay", 1)
+        request_retries = settings.get("max_retries", 5)
+
         if not api_id or not api_hash:
             error_msg = "API ID or API Hash not found in config. Please check your config file."
             self.logger.error(error_msg)
             raise ValueError(error_msg)
-        
+
         self.logger.debug(f"Connecting to Telegram with API ID: {api_id}")
         self.logger.debug(f"Session file: {session_file}")
-        
+
         try:
             # Initialize the client
             self.client = TelegramClient(
@@ -200,16 +225,14 @@ class TelegramChatDownloader:
                 api_id=api_id,
                 api_hash=api_hash,
                 request_retries=request_retries,
-                flood_sleep_threshold=request_delay
+                flood_sleep_threshold=request_delay,
             )
-            
+
             # Connect to Telegram
             await self.client.connect()
 
             is_authorized = await self.client.is_user_authorized()
-            self.logger.debug(
-                f"Connection status: is_authorized={is_authorized}, phone={phone}"
-            )
+            self.logger.debug(f"Connection status: is_authorized={is_authorized}, phone={phone}")
 
             # send code request
             if phone and not code and not is_authorized:
@@ -218,20 +241,17 @@ class TelegramChatDownloader:
                 self.phone_code_hash = sent_code.phone_code_hash
                 self.logger.info("Verification code sent to your Telegram account")
                 return
-            
+
             # login
             if phone and code and not is_authorized:
                 try:
-                    if not hasattr(self, 'phone_code_hash'):
+                    if not hasattr(self, "phone_code_hash"):
                         error_msg = "Please request a verification code first"
                         self.logger.error(error_msg)
                         raise ValueError(error_msg)
-                        
+
                     await self.client.sign_in(
-                        phone=phone,
-                        code=code,
-                        phone_code_hash=self.phone_code_hash,
-                        password=password
+                        phone=phone, code=code, phone_code_hash=self.phone_code_hash, password=password
                     )
                     self.logger.info("Successfully authenticated with code")
                 except SessionPasswordNeededError:
@@ -239,7 +259,7 @@ class TelegramChatDownloader:
                         error_msg = "2FA is enabled but no password provided. Set password parameter."
                         self.logger.error(error_msg)
                         raise ValueError(error_msg) from None
-                    
+
                     self.logger.info("2FA password required")
                     await self.client.sign_in(password=password)
                     self.logger.info("Successfully authenticated with 2FA password")
@@ -249,7 +269,7 @@ class TelegramChatDownloader:
                     raise ValueError(error_msg) from e
             else:
                 self.logger.debug("Using existing session")
-                
+
             # Verify connection
             self.logger.debug("Retrieving current user via get_me()")
             me = await self.client.get_me()
@@ -272,7 +292,7 @@ class TelegramChatDownloader:
             self.logger.info(f"Successfully connected as {me.username or me.phone}")
             await self.client.start()
             return True
-            
+
         except ApiIdInvalidError as e:
             error_msg = "Invalid API ID or API Hash. Please check your credentials."
             self.logger.error(error_msg)
@@ -284,14 +304,22 @@ class TelegramChatDownloader:
         except Exception as e:
             error_msg = f"Failed to connect to Telegram: {str(e)}"
             self.logger.error(error_msg)
-            if hasattr(self, 'client') and self.client:
+            if hasattr(self, "client") and self.client:
                 await self.client.disconnect()
             raise RuntimeError(error_msg) from e
-    
-    async def download_chat(self, chat_id: str, request_limit: int = 100, total_limit: int = 0, output_file: Optional[str] = None, 
-                         save_partial: bool = True, silent: bool = False, until_date: Optional[str] = None) -> List[Dict[str, Any]]:
+
+    async def download_chat(
+        self,
+        chat_id: str,
+        request_limit: int = 100,
+        total_limit: int = 0,
+        output_file: Optional[str] = None,
+        save_partial: bool = True,
+        silent: bool = False,
+        until_date: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         """Download messages from a chat with support for partial downloads and resuming.
-        
+
         Args:
             chat_id: Username, phone number, or chat ID
             request_limit: Maximum number of messages to fetch per request (50-1000)
@@ -300,22 +328,23 @@ class TelegramChatDownloader:
             save_partial: If True, save partial results to a temporary file
             silent: If True, suppress progress output
             until_date: Only download messages until this date (format: YYYY-MM-DD)
-            
+
         Returns:
             List of message dictionaries
         """
         import sys
+
         from telethon.errors import FloodWaitError
         from telethon.tl.functions.messages import GetHistoryRequest
-        
+
         if not self.client:
             await self.connect()
-        
+
         entity = await self.get_entity(chat_id)
-            
+
         offset_id = 0
         all_messages = []
-        
+
         # Check for existing partial download
         output_path = Path(output_file) if output_file else None
         if output_file and save_partial:
@@ -325,11 +354,11 @@ class TelegramChatDownloader:
                 offset_id = last_id
                 if not silent:
                     self.logger.info(f"Resuming download from message ID {offset_id}...")
-        
+
         total_fetched = len(all_messages)
         last_save = asyncio.get_event_loop().time()
         save_interval = 60  # Save partial results every 60 seconds
-        
+
         while True:
             # Check for graceful shutdown request
             if self._stop_requested or (self._stop_file and self._stop_file.exists()):
@@ -337,7 +366,7 @@ class TelegramChatDownloader:
                 if not silent:
                     self.logger.info("Stop requested, breaking download loop...")
                 break
-                
+
             try:
                 history = await self.client(
                     GetHistoryRequest(
@@ -355,11 +384,11 @@ class TelegramChatDownloader:
                 wait = e.seconds + 1
                 if not silent:
                     self.logger.info(f"Flood-wait {wait}s, sleeping...")
-                
+
                 # Save progress before sleeping
                 if output_file and save_partial and all_messages:
                     self._save_partial_messages(all_messages, output_path)
-                    
+
                 await asyncio.sleep(wait)
                 continue
 
@@ -371,47 +400,45 @@ class TelegramChatDownloader:
             new_messages = []
             for msg in history.messages:
                 # Skip if message doesn't have an ID or if it already exists
-                if not hasattr(msg, 'id') or any(m.id == msg.id for m in all_messages if hasattr(m, 'id')):
+                if not hasattr(msg, "id") or any(m.id == msg.id for m in all_messages if hasattr(m, "id")):
                     continue
-                
+
                 # Filter by date if until_date is provided
-                if until_date and hasattr(msg, 'date') and msg.date:
+                if until_date and hasattr(msg, "date") and msg.date:
                     # Convert until_date to timezone-aware datetime at start of day
-                    until = datetime.strptime(until_date, '%Y-%m-%d').replace(
-                        tzinfo=timezone.utc
-                    )
-                    
+                    until = datetime.strptime(until_date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
                     # Ensure msg.date is timezone-aware (in case it's not already)
                     msg_date = msg.date
                     if msg_date.tzinfo is None:
                         msg_date = msg_date.replace(tzinfo=timezone.utc)
-                    
+
                     # Compare dates (not times)
                     if msg_date.date() < until.date():
                         if not silent:
                             self.logger.debug(f"Reached message from {msg_date} which is older than {until_date}")
                         break
-                
+
                 new_messages.append(msg)
-            
+
             all_messages.extend(new_messages)
-            
+
             if not new_messages:
                 self.logger.debug("No new messages found, stopping")
                 break
-                
+
             # If we broke out of the loop early due to date filtering, we're done
             if until_date and len(new_messages) < len(history.messages):
                 if not silent:
                     self.logger.info(f"Reached messages older than {until_date}, stopping")
                 break
-                
+
             # Update offset to the oldest message we just fetched
             offset_id = min(msg.id for msg in history.messages)
             total_fetched = len(all_messages)
-            
+
             current_time = asyncio.get_event_loop().time()
-            
+
             # Save partial results periodically
             if output_file and save_partial and current_time - last_save > save_interval:
                 self._save_partial_messages(all_messages, output_path)
@@ -431,7 +458,6 @@ class TelegramChatDownloader:
             all_messages = all_messages[:total_limit]
 
         return all_messages
-    
 
     async def fetch_user_name(self, user_id: int) -> str:
         """Fetch full name for a user from Telegram."""
@@ -450,25 +476,25 @@ class TelegramChatDownloader:
             return name
         except Exception:
             return str(user_id)
-    
+
     def _save_config(self):
         """Save the current config to the config file."""
-        with open(self.config_path, 'w', encoding='utf-8') as f:
+        with open(self.config_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(self.config, f, allow_unicode=True)
-    
+
     async def _get_user_display_name(self, user_id: int) -> str:
         """Get display name from users_map or return ID as string."""
         if not user_id:
             return "Unknown"
-        if user_id in self.config.get('users_map', {}):
-            return self.config['users_map'][user_id]
+        if user_id in self.config.get("users_map", {}):
+            return self.config["users_map"][user_id]
         else:
             fetched_name = await self.fetch_user_name(user_id)
-            if not self.config.get('users_map', {}):
-                self.config['users_map'] = {}
-            self.config['users_map'][user_id] = fetched_name
+            if not self.config.get("users_map", {}):
+                self.config["users_map"] = {}
+            self.config["users_map"][user_id] = fetched_name
             self._fetched_usernames_count += 1
-            
+
             # Log every 100 fetched usernames
             if self._fetched_usernames_count % 100 == 0:
                 self._save_config()
@@ -505,9 +531,7 @@ class TelegramChatDownloader:
             self._fetched_chatnames_count += 1
             if self._fetched_chatnames_count % 100 == 0:
                 self._save_config()
-                self.logger.info(
-                    f"Fetched {self._fetched_chatnames_count} chat names so far"
-                )
+                self.logger.info(f"Fetched {self._fetched_chatnames_count} chat names so far")
             return name
 
         # Fallback: treat as user if type could not be determined
@@ -520,15 +544,10 @@ class TelegramChatDownloader:
         # locations depending on how the message was obtained.  Prefer the
         # explicit ``from_id``/``sender_id`` fields when available and fall back
         # to ``peer_id`` only if those are missing.
-        sender = msg.get('from_id') or msg.get('sender_id') or msg.get('peer_id')
+        sender = msg.get("from_id") or msg.get("sender_id") or msg.get("peer_id")
 
         if isinstance(sender, dict):
-            sender = (
-                sender.get('user_id')
-                or sender.get('channel_id')
-                or sender.get('chat_id')
-                or sender
-            )
+            sender = sender.get("user_id") or sender.get("channel_id") or sender.get("chat_id") or sender
 
         try:
             return int(sender)
@@ -537,33 +556,31 @@ class TelegramChatDownloader:
 
     def _get_recipient_id(self, msg: Dict[str, Any]) -> Optional[int]:
         """Determine the recipient ID for arrow formatting."""
-        peer = msg.get('peer_id') or msg.get('to_id')
+        peer = msg.get("peer_id") or msg.get("to_id")
         sender_id = self._get_sender_id(msg)
 
         if isinstance(peer, dict):
-            if 'user_id' in peer:
-                other_id = peer.get('user_id')
+            if "user_id" in peer:
+                other_id = peer.get("user_id")
                 if self._self_id and sender_id != self._self_id:
                     return self._self_id
                 return other_id
-            peer = (
-                peer.get('channel_id')
-                or peer.get('chat_id')
-                or peer
-            )
+            peer = peer.get("channel_id") or peer.get("chat_id") or peer
 
         try:
             return int(peer)
         except (TypeError, ValueError):
             return None
-    
-    def convert_archive_to_messages(self, archive: Dict[str, Any], user_filter: Optional[str] = None) -> List[Dict[str, Any]]:
+
+    def convert_archive_to_messages(
+        self, archive: Dict[str, Any], user_filter: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
         """Convert Telegram archive to list of messages.
-        
+
         Args:
             archive: Dictionary containing the Telegram export data
             user_filter: Optional user ID to filter messages by sender (e.g., '12345' or 'user12345')
-            
+
         Returns:
             List of formatted message dictionaries
         """
@@ -571,114 +588,168 @@ class TelegramChatDownloader:
         if user_filter:
             self.logger.info(f"Filtering messages by user: {user_filter}")
             # Remove 'user' prefix if present for comparison
-            user_filter = user_filter.replace('user', '') if user_filter and user_filter.startswith('user') else user_filter
-            
+            user_filter = (
+                user_filter.replace("user", "") if user_filter and user_filter.startswith("user") else user_filter
+            )
+
         messages = []
-        
-        chats = archive.get('chats', {}).get('list', [])
-        left_chats = archive.get('left_chats', {}).get('list', [])
+
+        chats = archive.get("chats", {}).get("list", [])
+        left_chats = archive.get("left_chats", {}).get("list", [])
         chats.extend(left_chats)
 
         self.logger.info(f"Found {len(chats)} chats, including {len(left_chats)} left chats")
         for chat in chats:
-            chat_id = chat.get('id')
+            chat_id = chat.get("id")
             if not chat_id:
                 continue
-                
-            for message in chat.get('messages', []):
+
+            for message in chat.get("messages", []):
                 # Skip non-message types
-                if message.get('type') != 'message':
+                if message.get("type") != "message":
                     continue
-                    
+
                 # Handle text content (can be string, list of strings/objects, or None)
-                text = message.get('text', '')
+                text = message.get("text", "")
                 if isinstance(text, list):
                     text_parts = []
                     for part in text:
                         if isinstance(part, str):
                             text_parts.append(part)
                         elif isinstance(part, dict):
-                            text_parts.append(part.get('text', ''))
-                    text = ''.join(text_parts)
+                            text_parts.append(part.get("text", ""))
+                    text = "".join(text_parts)
                 elif not isinstance(text, str):
                     text = str(text)
-                    
+
                 # Get user ID from from_id (handling both 'user123' format and direct IDs)
-                from_id = message.get('from_id', '')
-                if isinstance(from_id, str) and from_id.startswith('user'):
+                from_id = message.get("from_id", "")
+                if isinstance(from_id, str) and from_id.startswith("user"):
                     try:
                         user_id = int(from_id[4:])  # Remove 'user' prefix
                     except (ValueError, TypeError):
                         user_id = from_id  # Fallback to original if conversion fails
                 else:
                     user_id = from_id
-                    
+
                 # Skip if user filter is set and doesn't match
                 if user_filter and str(user_id) != user_filter:
                     continue
-                    
+
                 # Format the message
                 formatted = {
-                    'id': message.get('id'),
-                    'peer_id': {
-                        '_': 'PeerChat' if chat.get('type') == 'group' else 'PeerChannel',
-                        'channel_id' if chat.get('type') in ['channel', 'public_supergroup'] 
-                            else 'user_id': chat_id
+                    "id": message.get("id"),
+                    "peer_id": {
+                        "_": "PeerChat" if chat.get("type") == "group" else "PeerChannel",
+                        "channel_id" if chat.get("type") in ["channel", "public_supergroup"] else "user_id": chat_id,
                     },
-                    'date': message.get('date'),
-                    'message': text,
-                    'from_id': {
-                        '_': 'PeerUser',
-                        'user_id': user_id
-                    }
+                    "date": message.get("date"),
+                    "message": text,
+                    "from_id": {"_": "PeerUser", "user_id": user_id},
                 }
-                
+
                 # Add reply info if exists
-                if 'reply_to_message_id' in message:
-                    formatted['reply_to_msg_id'] = message['reply_to_message_id']
-                    
+                if "reply_to_message_id" in message:
+                    formatted["reply_to_msg_id"] = message["reply_to_message_id"]
+
                 messages.append(formatted)
-        
+
         return messages
-    
-    async def save_messages_as_txt(self, messages: List[Dict[str, Any]], txt_path: Path) -> int:
+
+    def prepare_messages_for_txt(
+        self, messages: List[Dict[str, Any]], sort_order: str = "desc"
+    ) -> List[Dict[str, Any]]:
+        """Sort messages and place replied-to messages before replies."""
+        from datetime import datetime
+
+        def parse_dt(msg):
+            date_str = msg.get("date")
+            if not date_str:
+                return datetime.min
+            try:
+                return datetime.fromisoformat(str(date_str).replace("Z", "+00:00"))
+            except Exception:
+                return datetime.min
+
+        sorted_msgs = sorted(messages, key=parse_dt, reverse=(sort_order == "desc"))
+        id_map = {m.get("id"): m for m in sorted_msgs if m.get("id") is not None}
+        inserted = set()
+        result = []
+
+        for msg in sorted_msgs:
+            msg_id = msg.get("id")
+            if msg_id in inserted:
+                continue
+
+            chain = []
+            current = msg
+            visited = set()
+            while True:
+                reply = current.get("reply_to") or {}
+                reply_id = reply.get("reply_to_msg_id") or current.get("reply_to_msg_id")
+                if not reply_id or reply_id in visited:
+                    break
+                visited.add(reply_id)
+                parent = id_map.get(reply_id)
+                if not parent or parent.get("id") in inserted:
+                    break
+                chain.append(parent)
+                current = parent
+
+            for parent in reversed(chain):
+                pid = parent.get("id")
+                if pid not in inserted:
+                    result.append(parent)
+                    inserted.add(pid)
+
+            result.append(msg)
+            if msg_id is not None:
+                inserted.add(msg_id)
+
+        return result
+
+    async def save_messages_as_txt(
+        self, messages: List[Dict[str, Any]], txt_path: Path, sort_order: str = "desc"
+    ) -> int:
         """Save messages to a human-readable text file.
-         
+
         Args:
             messages: List of message dictionaries
             txt_path: Path to save the text file
-            
+
         Returns:
             Number of messages successfully saved
         """
         saved = 0
         txt_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(txt_path, 'w', encoding='utf-8') as f:
-            for msg in messages:
+        ordered_messages = self.prepare_messages_for_txt(messages, sort_order)
+
+        with open(txt_path, "w", encoding="utf-8") as f:
+            for msg in ordered_messages:
                 try:
                     # Format date
-                    date_str = msg.get('date', '')
+                    date_str = msg.get("date", "")
                     if date_str:
                         try:
-                            dt = datetime.fromisoformat(date_str.replace('Z', '+00:00'))
-                            date_fmt = dt.strftime('%Y-%m-%d %H:%M:%S')
+                            dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+                            date_fmt = dt.strftime("%Y-%m-%d %H:%M:%S")
                         except (ValueError, TypeError):
-                            date_fmt = ''
+                            date_fmt = ""
                     else:
-                        date_fmt = ''
-                    
+                        date_fmt = ""
+
                     # Get sender name
-                    sender_name = ''
+                    sender_name = ""
                     sender_id = self._get_sender_id(msg)
                     if sender_id:
                         sender_name = await self._get_user_display_name(sender_id)
-                    
+
                     # Get message text
-                    text = msg.get('text', '')
-                    if not text and 'message' in msg:  # Fallback for different message formats
-                        text = msg['message']
-                    
+                    text = msg.get("text", "")
+                    if not text and "message" in msg:  # Fallback for different message formats
+                        text = msg["message"]
+
                     # Get recipient name
                     recipient_name = ""
                     recipient_id = self._get_recipient_id(msg)
@@ -696,12 +767,12 @@ class TelegramChatDownloader:
                     saved += 1
                 except Exception as e:
                     logging.warning(f"Error saving message to TXT: {e}")
-        
+
         if self._fetched_usernames_count > 0 or self._fetched_chatnames_count > 0:
             self._save_config()
 
         return saved
-    
+
     def make_serializable(self, obj):
         """Recursively make an object JSON serializable."""
         if isinstance(obj, dict):
@@ -716,10 +787,12 @@ class TelegramChatDownloader:
                 return str(obj)
             except Exception:
                 return None
-    
-    async def save_messages(self, messages: List[Message], output_file: str, save_txt: bool = True) -> None:
+
+    async def save_messages(
+        self, messages: List[Message], output_file: str, save_txt: bool = True, sort_order: str = "desc"
+    ) -> None:
         """Save messages to JSON and optionally to TXT.
-        
+
         Args:
             messages: List of message dictionaries to save
             output_file: Path to save the JSON file
@@ -731,62 +804,58 @@ class TelegramChatDownloader:
         serializable_messages = []
         for msg in messages:
             try:
-                msg_dict = msg.to_dict() if hasattr(msg, 'to_dict') else msg
+                msg_dict = msg.to_dict() if hasattr(msg, "to_dict") else msg
                 serializable_messages.append(self.make_serializable(msg_dict))
             except Exception as e:
                 self.logger.warning(f"Failed to serialize message: {e}")
 
         # Save JSON
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, 'w', encoding='utf-8') as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(serializable_messages, f, ensure_ascii=False, indent=2)
-        
+
         # Save TXT if requested
         if save_txt:
-            txt_path = output_path.with_suffix('.txt')
-            saved = await self.save_messages_as_txt(serializable_messages, txt_path)
+            txt_path = output_path.with_suffix(".txt")
+            saved = await self.save_messages_as_txt(serializable_messages, txt_path, sort_order)
             txt_path_relative = get_relative_to_downloads_dir(txt_path)
             self.logger.info(f"Saved {saved} messages to {txt_path_relative}")
-        
+
         partial = self.get_temp_file_path(output_path)
         if partial.exists() and not self._stop_requested:
             self.logger.debug(f"Removing partial file: {partial}")
             partial.unlink()
-        
+
         output_file_relative = get_relative_to_downloads_dir(output_path)
         self.logger.info(f"Saved {len(messages)} messages to {output_file_relative}")
-    
+
     async def get_entity(self, identifier: str) -> Optional[Union[User, Chat, Channel]]:
         """Get Telegram entity by identifier (username, URL, or ID).
-        
+
         Args:
             identifier: Telegram entity identifier
                 - Username: @username
                 - URL: https://t.me/username
                 - ID: 123456789 or "-1001234567890" (user_id, group_id, or channel_id)
                 - Phone number: +1234567890
-                
+
         Returns:
             Telegram entity object (User, Chat, or Channel) or None if not found
         """
         try:
             if not self.client or not self.client.is_connected():
                 await self.connect()
-            
+
             self.logger.debug(f"Resolving entity: {identifier}")
-            
+
             # Handle numeric IDs (either as int or string)
-            if isinstance(identifier, (int, str)) and str(identifier).lstrip('-').isdigit():
+            if isinstance(identifier, (int, str)) and str(identifier).lstrip("-").isdigit():
                 id_value = int(identifier)
                 self.logger.debug(f"Trying to resolve numeric ID: {id_value}")
-                
+
                 # Try different peer types
-                peer_types = [
-                    (PeerChannel, 'channel/supergroup'),
-                    (PeerChat, 'basic group'),
-                    (PeerUser, 'user')
-                ]
-                
+                peer_types = [(PeerChannel, "channel/supergroup"), (PeerChat, "basic group"), (PeerUser, "user")]
+
                 for peer_cls, peer_type in peer_types:
                     try:
                         self.logger.debug(f"Trying to resolve as {peer_type}...")
@@ -799,30 +868,30 @@ class TelegramChatDownloader:
                     except Exception as e:
                         self.logger.debug(f"Unexpected error resolving as {peer_type}: {str(e)}")
                         continue
-                        
+
                 self.logger.warning(f"Could not resolve ID {id_value} as any peer type, trying alternative methods...")
-                
+
                 # Try to get the entity by first getting all dialogs
                 try:
                     self.logger.debug("Trying to find entity in dialogs...")
                     async for dialog in self.client.iter_dialogs():
-                        if hasattr(dialog.entity, 'id') and dialog.entity.id == abs(id_value):
+                        if hasattr(dialog.entity, "id") and dialog.entity.id == abs(id_value):
                             self.logger.debug(f"Found entity in dialogs: {dialog.entity}")
                             return dialog.entity
                 except Exception as e:
                     self.logger.debug(f"Error searching in dialogs: {str(e)}")
-                
+
                 # Try to get the entity by its ID directly (sometimes works for private chats)
                 try:
                     self.logger.debug("Trying direct entity access...")
                     return await self.client.get_entity(PeerChannel(abs(id_value)))
                 except Exception as e:
                     self.logger.debug(f"Direct entity access failed: {str(e)}")
-                
+
                 # If we're here, we couldn't find the entity
                 self.logger.warning(f"Could not find entity with ID {id_value} using any method")
                 return None
-            
+
             # For strings (usernames, URLs, phone numbers)
             self.logger.debug(f"Trying to resolve as string identifier...")
             try:
@@ -832,7 +901,7 @@ class TelegramChatDownloader:
             except Exception as e:
                 self.logger.debug(f"Failed to resolve string identifier: {str(e)}")
                 raise
-                
+
         except Exception as e:
             self.logger.error(f"Error getting entity {identifier}: {str(e)}")
             # Try one more time with a fresh connection
@@ -847,187 +916,190 @@ class TelegramChatDownloader:
 
     async def get_entity_name(self, chat_identifier: str) -> str:
         """Get the name of a Telegram entity using client.get_entity().
-        
+
         Args:
             chat_identifier: Telegram entity identifier (username, URL, etc.)
                 Examples:
                 - @username
                 - https://t.me/username
                 - https://t.me/+invite_code
-                
+
         Returns:
             Clean, filesystem-safe name of the entity
         """
         if not chat_identifier:
-            return 'chat_history'
-            
+            return "chat_history"
+
         try:
             entity = await self.get_entity(chat_identifier)
             if not entity:
                 return None
-                
+
             # Get the appropriate name based on entity type
-            if hasattr(entity, 'title'):  # For chats/channels
+            if hasattr(entity, "title"):  # For chats/channels
                 name = entity.title
-            elif hasattr(entity, 'username') and entity.username:  # For users with username
+            elif hasattr(entity, "username") and entity.username:  # For users with username
                 name = entity.username
-            elif hasattr(entity, 'first_name') or hasattr(entity, 'last_name'):  # For users
-                name = ' '.join(filter(None, [getattr(entity, 'first_name', ''), getattr(entity, 'last_name', '')]))
+            elif hasattr(entity, "first_name") or hasattr(entity, "last_name"):  # For users
+                name = " ".join(filter(None, [getattr(entity, "first_name", ""), getattr(entity, "last_name", "")]))
             else:
                 name = str(entity.id)
-                
+
             # Clean the name for filesystem use
-            safe_name = re.sub(r'[^\w\-_.]', '_', name.strip())
-            return safe_name or 'chat_history'
-            
+            safe_name = re.sub(r"[^\w\-_.]", "_", name.strip())
+            return safe_name or "chat_history"
+
         except Exception as e:
             # Fallback to basic parsing if client is not available or entity not found
             chat = chat_identifier
-            if chat.startswith('@'):
+            if chat.startswith("@"):
                 chat = chat[1:]
-            elif '//' in chat:
-                chat = chat.split('?')[0].rstrip('/').split('/')[-1]
-                if chat.startswith('+'):
-                    chat = 'invite_' + chat[1:]
-            
-            safe_name = re.sub(r'[^\w\-_.]', '_', chat)
-            return safe_name or 'chat_history'
+            elif "//" in chat:
+                chat = chat.split("?")[0].rstrip("/").split("/")[-1]
+                if chat.startswith("+"):
+                    chat = "invite_" + chat[1:]
+
+            safe_name = re.sub(r"[^\w\-_.]", "_", chat)
+            return safe_name or "chat_history"
 
     async def get_entity_full_name(self, identifier: Union[str, int]) -> str:
         """Return the raw title or name for a chat/channel/user."""
         if not identifier:
-            return 'Unknown'
+            return "Unknown"
         try:
             entity = await self.get_entity(identifier)
             if not entity:
                 return str(identifier)
 
-            if hasattr(entity, 'title'):
+            if hasattr(entity, "title"):
                 return entity.title
-            if hasattr(entity, 'first_name') or hasattr(entity, 'last_name'):
-                name = ' '.join(filter(None, [getattr(entity, 'first_name', ''), getattr(entity, 'last_name', '')])).strip()
+            if hasattr(entity, "first_name") or hasattr(entity, "last_name"):
+                name = " ".join(
+                    filter(None, [getattr(entity, "first_name", ""), getattr(entity, "last_name", "")])
+                ).strip()
                 return name or str(identifier)
-            if hasattr(entity, 'username') and entity.username:
+            if hasattr(entity, "username") and entity.username:
                 return entity.username
 
             return str(identifier)
         except Exception:
             return str(identifier)
-    
+
     async def close(self) -> None:
         """Close the Telegram client connection."""
         if self.client and self.client.is_connected():
             await self.client.disconnect()
             self.client = None
-    
+
     def get_temp_file_path(self, output_file: Path) -> Path:
         """Get path for temporary file to store partial downloads.
-        
+
         Args:
             output_file: The target output file path
-            
+
         Returns:
             Path: Temporary file path with .part.jsonl extension
         """
         # Return path with .part.jsonl extension
-        return output_file.with_suffix('.part.jsonl')
-    
+        return output_file.with_suffix(".part.jsonl")
+
     def _save_partial_messages(self, messages: List[Dict[str, Any]], output_file: Path) -> None:
         """Save messages to a temporary file for partial downloads using JSONL format.
-        
+
         Each line is a separate JSON object with two fields:
         - 'm': message data
         - 'i': message ID (for resuming)
-        
+
         Only new messages (not already in the file) are appended.
         Check only last 10000 messages.
         """
         import json
         import time
-        
+
         start_time = time.time()
         temp_file = self.get_temp_file_path(output_file)
         temp_file.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Load existing message IDs to avoid duplicates (only last 10k lines for performance)
         existing_ids = set()
         if temp_file.exists():
             try:
-                with open(temp_file, 'r', encoding='utf-8') as f:
+                with open(temp_file, "r", encoding="utf-8") as f:
                     # Read all lines first, then take only the last 10k
                     all_lines = f.readlines()
                     last_10k_lines = all_lines[-10000:] if len(all_lines) > 10000 else all_lines
-                    
+
                     for line in last_10k_lines:
                         line = line.strip()
                         if not line:
                             continue
                         try:
                             data = json.loads(line)
-                            if isinstance(data, dict) and 'i' in data:
-                                existing_ids.add(data['i'])
+                            if isinstance(data, dict) and "i" in data:
+                                existing_ids.add(data["i"])
                         except json.JSONDecodeError:
                             continue
             except IOError:
                 pass
-        
+
         # Append only new messages in JSONL format
         new_saved_count = 0
-        with open(temp_file, 'a', encoding='utf-8') as f:
+        with open(temp_file, "a", encoding="utf-8") as f:
             for msg in messages[-10000:]:
                 try:
                     # Convert message to serializable format
-                    msg_dict = msg.to_dict() if hasattr(msg, 'to_dict') else msg
+                    msg_dict = msg.to_dict() if hasattr(msg, "to_dict") else msg
                     serialized = self.make_serializable(msg_dict)
                     # Get message ID, defaulting to 0 if not found
-                    msg_id = msg_dict.get('id') if hasattr(msg_dict, 'get') else getattr(msg_dict, 'id', 0)
-                    
+                    msg_id = msg_dict.get("id") if hasattr(msg_dict, "get") else getattr(msg_dict, "id", 0)
+
                     # Only append if this message ID is not already in the file
                     if msg_id not in existing_ids:
                         # Write as a single line
-                        json.dump({'m': serialized, 'i': msg_id}, f, ensure_ascii=False)
-                        f.write('\n')  # Add newline for JSONL format
+                        json.dump({"m": serialized, "i": msg_id}, f, ensure_ascii=False)
+                        f.write("\n")  # Add newline for JSONL format
                         existing_ids.add(msg_id)  # Track this ID to avoid duplicates in this batch
                         new_saved_count += 1
                 except Exception as e:
                     self.logger.warning(f"Failed to serialize message: {e}")
-        
+
         save_time = time.time() - start_time
         self.logger.info(f"Saved {new_saved_count} new messages to partial file in {save_time:.2f}s")
-    
+
     def _load_partial_messages(self, output_file: Path) -> tuple[list[Dict[str, Any]], int]:
         """Load messages from a temporary JSONL file if it exists.
-        
+
         Returns:
             tuple: (list of messages, last message ID)
         """
         import json
+
         temp_file = self.get_temp_file_path(output_file)
-        
+
         if not temp_file.exists():
             return [], 0
-            
+
         messages = []
         last_id = 0
-        
+
         try:
-            with open(temp_file, 'r', encoding='utf-8') as f:
+            with open(temp_file, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if not line:
                         continue
-                        
+
                     try:
                         data = json.loads(line)
-                        if isinstance(data, dict) and 'm' in data:
-                            messages.append(data['m'])
-                            last_id = data.get('i', last_id)  # Update last_id if present
+                        if isinstance(data, dict) and "m" in data:
+                            messages.append(data["m"])
+                            last_id = data.get("i", last_id)  # Update last_id if present
                     except json.JSONDecodeError as e:
                         logging.warning(f"Skipping invalid JSON line: {e}")
                         continue
-                        
+
             return messages, last_id
-            
+
         except (IOError, json.JSONDecodeError) as e:
             logging.warning(f"Error loading partial messages: {e}")
             return [], 0

--- a/tests/test_telegram_download_chat.py
+++ b/tests/test_telegram_download_chat.py
@@ -1,4 +1,5 @@
 """Tests for telegram-download-chat package."""
+
 import asyncio
 import json
 import logging
@@ -6,42 +7,50 @@ import os
 import re
 import sys
 from io import StringIO
-import pytest
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, AsyncIterator
-from unittest.mock import AsyncMock, MagicMock, Mock, patch, mock_open
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
+from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
 
-from telegram_download_chat.cli import parse_args, filter_messages_by_subchat, async_main
+import pytest
+
+from telegram_download_chat.cli import (
+    async_main,
+    filter_messages_by_subchat,
+    parse_args,
+)
 from telegram_download_chat.core import TelegramChatDownloader
 
 
 @pytest.fixture
 def mock_downloader():
     """Fixture that mocks TelegramChatDownloader."""
-    with patch('telegram_download_chat.cli.TelegramChatDownloader') as mock_cls:
+    with patch("telegram_download_chat.cli.TelegramChatDownloader") as mock_cls:
         mock_instance = mock_cls.return_value
         mock_instance.config = {}
         mock_instance.logger = MagicMock()
         yield mock_instance
 
+
 class TestCLIArgumentParsing:
     """Tests for command line argument parsing."""
-    
+
     def test_required_chat_argument(self):
         """Test that chat argument is required for normal operation."""
         # When no chat is provided and --show-config is not used
-        with patch('sys.argv', ['script_name']):
+        with patch("sys.argv", ["script_name"]):
             args = parse_args()
             assert args.chat is None  # argparse doesn't raise, but chat will be None
-    
+
     def test_basic_chat_argument(self):
         """Test basic chat argument parsing."""
         test_chat = "test_chat"
-        with patch('sys.argv', ['script_name', test_chat]):
+        with patch("sys.argv", ["script_name", test_chat]):
             args = parse_args()
             assert args.chat == test_chat
             assert args.limit == 0  # Default value from cli.py
             assert args.output is None
+            assert args.sort == "desc"
+
 
 class TestFilterMessagesBySubchat:
     """Tests for filter_messages_by_subchat function."""
@@ -49,93 +58,101 @@ class TestFilterMessagesBySubchat:
     def test_filter_by_integer_id(self):
         """Test filtering messages by integer message ID."""
         messages = [
-            {'id': 1, 'reply_to': {'reply_to_msg_id': 123}},
-            {'id': 2, 'reply_to': {'reply_to_msg_id': 456}},
-            {'id': 3, 'reply_to': {'reply_to_msg_id': 123}},
-            {'id': 4, 'reply_to': None},
+            {"id": 1, "reply_to": {"reply_to_msg_id": 123}},
+            {"id": 2, "reply_to": {"reply_to_msg_id": 456}},
+            {"id": 3, "reply_to": {"reply_to_msg_id": 123}},
+            {"id": 4, "reply_to": None},
         ]
-        filtered = filter_messages_by_subchat(messages, '123')
+        filtered = filter_messages_by_subchat(messages, "123")
         assert len(filtered) == 2
-        assert filtered[0]['id'] == 1
-        assert filtered[1]['id'] == 3
+        assert filtered[0]["id"] == 1
+        assert filtered[1]["id"] == 3
 
     def test_filter_by_url(self):
         """Test filtering messages by Telegram chat URL."""
         messages = [
-            {'id': 1, 'reply_to': {'reply_to_msg_id': 123}},
-            {'id': 2, 'reply_to': {'reply_to_msg_id': 456}},
-            {'id': 3, 'reply_to': {'reply_to_msg_id': 123}},
-            {'id': 4, 'reply_to': None},
+            {"id": 1, "reply_to": {"reply_to_msg_id": 123}},
+            {"id": 2, "reply_to": {"reply_to_msg_id": 456}},
+            {"id": 3, "reply_to": {"reply_to_msg_id": 123}},
+            {"id": 4, "reply_to": None},
         ]
-        filtered = filter_messages_by_subchat(messages, 'https://t.me/c/123456789/123')
+        filtered = filter_messages_by_subchat(messages, "https://t.me/c/123456789/123")
         assert len(filtered) == 2
-        assert filtered[0]['id'] == 1
-        assert filtered[1]['id'] == 3
+        assert filtered[0]["id"] == 1
+        assert filtered[1]["id"] == 3
 
     def test_invalid_url_format(self):
         """Test handling of invalid Telegram chat URL format."""
         messages = [
-            {'id': 1, 'reply_to': {'reply_to_msg_id': 123}},
+            {"id": 1, "reply_to": {"reply_to_msg_id": 123}},
         ]
         with pytest.raises(ValueError, match="Invalid message ID in URL"):
-            filter_messages_by_subchat(messages, 'https://t.me/c/123456789/abc')
+            filter_messages_by_subchat(messages, "https://t.me/c/123456789/abc")
 
     def test_invalid_url_format_empty(self):
         """Test handling of empty URL format."""
         messages = [
-            {'id': 1, 'reply_to': {'reply_to_msg_id': 123}},
+            {"id": 1, "reply_to": {"reply_to_msg_id": 123}},
         ]
         with pytest.raises(ValueError):
-            filter_messages_by_subchat(messages, 'https://t.me/c/')
+            filter_messages_by_subchat(messages, "https://t.me/c/")
 
     def test_invalid_integer_id(self):
         """Test handling of invalid integer ID format."""
         messages = [
-            {'id': 1, 'reply_to': {'reply_to_msg_id': 123}},
+            {"id": 1, "reply_to": {"reply_to_msg_id": 123}},
         ]
         with pytest.raises(ValueError, match="Invalid message ID format"):
-            filter_messages_by_subchat(messages, 'abc')
+            filter_messages_by_subchat(messages, "abc")
 
     def test_no_reply_to(self):
         """Test filtering when message has no reply_to field."""
         messages = [
-            {'id': 1, 'reply_to': None},
-            {'id': 2, 'reply_to': None},
-            {'id': 3, 'reply_to': {'reply_to_msg_id': 123}},
+            {"id": 1, "reply_to": None},
+            {"id": 2, "reply_to": None},
+            {"id": 3, "reply_to": {"reply_to_msg_id": 123}},
         ]
-        filtered = filter_messages_by_subchat(messages, '123')
+        filtered = filter_messages_by_subchat(messages, "123")
         assert len(filtered) == 1
-        assert filtered[0]['id'] == 3
+        assert filtered[0]["id"] == 3
 
     def test_empty_messages_list(self):
         """Test filtering with empty messages list."""
-        filtered = filter_messages_by_subchat([], '123')
+        filtered = filter_messages_by_subchat([], "123")
         assert filtered == []
 
     def test_string_comparison(self):
         """Test that non-numeric subchat_id raises ValueError."""
         messages = [
-            {'id': 1, 'reply_to': {'reply_to_msg_id': 'abc'}},
-            {'id': 2, 'reply_to': {'reply_to_msg_id': 'xyz'}},
-            {'id': 3, 'reply_to': {'reply_to_msg_id': 'abc'}},
+            {"id": 1, "reply_to": {"reply_to_msg_id": "abc"}},
+            {"id": 2, "reply_to": {"reply_to_msg_id": "xyz"}},
+            {"id": 3, "reply_to": {"reply_to_msg_id": "abc"}},
         ]
         with pytest.raises(ValueError, match="Invalid message ID format: abc"):
-            filter_messages_by_subchat(messages, 'abc')
-    
+            filter_messages_by_subchat(messages, "abc")
+
     def test_all_arguments(self):
         """Test parsing of all command line arguments."""
         test_args = [
-            'script_name',
+            "script_name",
             "test_chat",
-            "--limit", "100",
-            "--output", "output.json",
-            "--config", "custom_config.yml",
+            "--limit",
+            "100",
+            "--output",
+            "output.json",
+            "--config",
+            "custom_config.yml",
             "--debug",
-            "--subchat", "123",
-            "--subchat-name", "custom_subchat",
-            "--until", "2025-01-01"
+            "--subchat",
+            "123",
+            "--subchat-name",
+            "custom_subchat",
+            "--until",
+            "2025-01-01",
+            "--sort",
+            "asc",
         ]
-        with patch('sys.argv', test_args):
+        with patch("sys.argv", test_args):
             args = parse_args()
             assert args.chat == "test_chat"
             assert args.limit == 100
@@ -145,31 +162,32 @@ class TestFilterMessagesBySubchat:
             assert args.subchat == "123"
             assert args.subchat_name == "custom_subchat"
             assert args.until == "2025-01-01"
-            
+            assert args.sort == "asc"
+
     def test_until_date_format_validation(self):
         """Test that invalid date formats are accepted by the parser but handled in async_main."""
-        with patch('sys.argv', ['script_name', 'test_chat', '--until', 'invalid-date']):
+        with patch("sys.argv", ["script_name", "test_chat", "--until", "invalid-date"]):
             args = parse_args()
             # The parser should accept any string for --until
-            assert args.until == 'invalid-date'
-            
+            assert args.until == "invalid-date"
+
     def test_until_date_without_chat(self):
         """Test that --until without chat argument is handled."""
-        with patch('sys.argv', ['script_name', '--until', '2025-01-01']):
+        with patch("sys.argv", ["script_name", "--until", "2025-01-01"]):
             args = parse_args()
             assert args.until == "2025-01-01"
-    
+
     def test_show_config_flag(self):
         """Test --show-config flag behavior."""
         # --show-config should make chat argument optional
-        with patch('sys.argv', ['script_name', '--show-config']):
+        with patch("sys.argv", ["script_name", "--show-config"]):
             args = parse_args()
             assert args.show_config is True
             assert args.chat is None
-    
+
     def test_json_conversion_mode(self):
         """Test JSON file input for conversion mode."""
-        with patch('sys.argv', ['script_name', 'chat_history.json']):
+        with patch("sys.argv", ["script_name", "chat_history.json"]):
             args = parse_args()
             assert args.chat == "chat_history.json"
             # Should not require --output for JSON input
@@ -179,76 +197,80 @@ class TestFilterMessagesBySubchat:
 
     def test_json_conversion_with_subchat_name(self):
         """Test JSON conversion with subchat-name option."""
-        with patch('sys.argv', ['script_name', 'chat_history.json', '--subchat', '123', '--subchat-name', 'custom_subchat']):
+        with patch(
+            "sys.argv", ["script_name", "chat_history.json", "--subchat", "123", "--subchat-name", "custom_subchat"]
+        ):
             args = parse_args()
             assert args.chat == "chat_history.json"
             assert args.subchat == "123"
             assert args.subchat_name == "custom_subchat"
 
+
 class TestCLIExecution:
     """Tests for CLI execution flow."""
-    
+
     def test_show_config(self, mock_downloader):
         """Test --show-config flag execution."""
         # Setup logger mock
         mock_logger = MagicMock()
         mock_downloader.logger = mock_logger
-        
+
         # Mock the config file content
-        config_content = 'test: config'
-        
+        config_content = "test: config"
+
         # Mock the config path
         mock_path = MagicMock()
         mock_path.exists.return_value = True
         mock_path.__str__.return_value = "/path/to/config.yml"
-        
-        with patch('sys.argv', ['script_name', '--show-config']), \
-             patch('telegram_download_chat.cli.Path', return_value=mock_path), \
-             patch('builtins.open', mock_open(read_data=config_content)), \
-             patch('telegram_download_chat.cli.TelegramChatDownloader', return_value=mock_downloader):
-            
+
+        with patch("sys.argv", ["script_name", "--show-config"]), patch(
+            "telegram_download_chat.cli.Path", return_value=mock_path
+        ), patch("builtins.open", mock_open(read_data=config_content)), patch(
+            "telegram_download_chat.cli.TelegramChatDownloader", return_value=mock_downloader
+        ):
+
             # Import here to avoid import issues with patching
             from telegram_download_chat.cli import main
-            
+
             # Mock the async_main function
             async def mock_async_main():
                 return 0
-                
+
             # Replace the actual async_main with our mock
-            with patch('telegram_download_chat.cli.async_main', new=mock_async_main):
+            with patch("telegram_download_chat.cli.async_main", new=mock_async_main):
                 # Run the main function
                 result = main()
-                
+
                 # Verify the result
                 assert result == 0, f"Expected return code 0, got {result}"
-    
+
     @pytest.mark.asyncio
     async def test_missing_chat_argument(self):
         """Test error when required chat argument is missing."""
         # Create a mock logger
         mock_logger = MagicMock()
-        
+
         # Create an AsyncMock for the downloader
         mock_downloader = AsyncMock()
         mock_downloader.logger = mock_logger
-        
+
         # Mock the command line arguments and downloader
-        with patch('sys.argv', ['script_name']), \
-             patch('telegram_download_chat.cli.TelegramChatDownloader', return_value=mock_downloader):
-            
+        with patch("sys.argv", ["script_name"]), patch(
+            "telegram_download_chat.cli.TelegramChatDownloader", return_value=mock_downloader
+        ):
+
             # Call the async_main function
             result = await async_main()
-            
+
             # Verify it returns error code 1
             assert result == 1
-            
+
             # Verify the error message was logged
             error_found = any(
-                args and args[0] == "Chat identifier is required"
-                for args, _ in mock_logger.error.call_args_list
+                args and args[0] == "Chat identifier is required" for args, _ in mock_logger.error.call_args_list
             )
             assert error_found, "Expected error message 'Chat identifier is required' not found"
-    
+
     @pytest.mark.asyncio
     async def test_json_conversion_flow(self, tmp_path):
         """Test JSON conversion flow."""
@@ -256,93 +278,88 @@ class TestCLIExecution:
         test_json = tmp_path / "test.json"
         test_messages = [{"id": 1, "message": "Test message 1"}, {"id": 2, "message": "Test message 2"}]
         test_json.write_text(json.dumps(test_messages))
-        
+
         # Create an AsyncMock for the downloader
         mock_downloader = AsyncMock()
-        
+
         # Mock the downloads directory to be our temp directory
-        mock_config = {
-            'settings': {
-                'save_path': str(tmp_path)
-            }
-        }
+        mock_config = {"settings": {"save_path": str(tmp_path)}}
         mock_downloader.config = mock_config
-        
+
         # Mock the logger
         mock_logger = MagicMock()
         mock_downloader.logger = mock_logger
-        
+
         # Mock the save_messages_as_txt method to return the number of messages
         mock_downloader.save_messages_as_txt.return_value = len(test_messages)
-        
-        with patch('sys.argv', ['script_name', str(test_json)]), \
-             patch('telegram_download_chat.cli.TelegramChatDownloader', return_value=mock_downloader), \
-             patch('telegram_download_chat.paths.get_app_dir', return_value=tmp_path):
-            
+
+        with patch("sys.argv", ["script_name", str(test_json)]), patch(
+            "telegram_download_chat.cli.TelegramChatDownloader", return_value=mock_downloader
+        ), patch("telegram_download_chat.paths.get_app_dir", return_value=tmp_path):
+
             # Mock the file operations
-            with patch('builtins.open', mock_open()) as mock_file:
+            with patch("builtins.open", mock_open()) as mock_file:
                 # Mock the json.load to return our test messages
-                with patch('json.load', return_value=test_messages):
+                with patch("json.load", return_value=test_messages):
                     result = await async_main()
-            
+
             # The function should return 0 on success
             assert result == 0
-            
+
             # Verify the logger was called with expected messages
             debug_messages = [call[0][0] for call in mock_logger.debug.call_args_list]
             assert any("Loading messages from JSON file:" in msg for msg in debug_messages)
-            
+
             # Verify save_messages_as_txt was called with the correct arguments
-            expected_output = test_json.with_suffix('.txt')
+            expected_output = test_json.with_suffix(".txt")
             mock_downloader.save_messages_as_txt.assert_called_once()
-            
-            # Get the arguments passed to save_messages_as_txt
+
             call_args = mock_downloader.save_messages_as_txt.call_args[0]
-            assert call_args[0] == test_messages  # Messages should match
-            assert str(call_args[1]) == str(expected_output)  # Output path should match
-    
+            assert call_args[0] == test_messages
+            assert str(call_args[1]) == str(expected_output)
+            assert call_args[2] == "desc"
 
     @pytest.mark.skip(reason="Skipping test_download_flow due to complexity of mocking.")
     @pytest.mark.asyncio
     async def test_download_flow(self, tmp_path, monkeypatch, capsys):
         """Test the complete chat download flow from CLI to file save."""
-        import sys
-        from unittest.mock import ANY, patch, MagicMock
-        import traceback
         import json
+        import sys
+        import traceback
         from pathlib import Path
-        
+        from unittest.mock import ANY, MagicMock, patch
+
         print("\n=== Starting test_download_flow ===")
         print(f"Temporary directory: {tmp_path}")
-        
+
         # Setup test data
         test_messages = [{"id": 1, "message": "Test message"}]
         test_chat = "test_chat"
-        
+
         # Create a test config file
         test_config = {
-            'settings': {
-                'save_path': str(tmp_path),
-                'api_id': 'test_api_id',
-                'api_hash': 'test_api_hash',
-                'phone': '+1234567890',
-                'session': 'test_session'
+            "settings": {
+                "save_path": str(tmp_path),
+                "api_id": "test_api_id",
+                "api_hash": "test_api_hash",
+                "phone": "+1234567890",
+                "session": "test_session",
             }
         }
-        
-        config_path = tmp_path / 'config.json'
-        with open(config_path, 'w') as f:
+
+        config_path = tmp_path / "config.json"
+        with open(config_path, "w") as f:
             json.dump(test_config, f)
-        
+
         print(f"Created test config at: {config_path}")
-        
+
         # Create a mock for the downloader class
         mock_downloader = MagicMock()
-        
+
         # Set up the async methods
         async def mock_async_method(*args, **kwargs):
             return None
-            
+
         # Configure the mock methods
         mock_downloader.download_chat = MagicMock(return_value=test_messages)
         mock_downloader.get_entity_name = MagicMock(return_value=test_chat)
@@ -350,17 +367,21 @@ class TestCLIExecution:
         mock_downloader.save_messages = MagicMock(return_value=len(test_messages))
         mock_downloader.close = MagicMock(side_effect=mock_async_method)
         mock_downloader.config = test_config
-        
+
         # Patch the downloader class to return our mock
-        with patch('telegram_download_chat.cli.TelegramChatDownloader', return_value=mock_downloader) as mock_tg_class, \
-             patch('telegram_download_chat.paths.get_app_dir', return_value=tmp_path), \
-             patch('sys.argv', ['script.py', test_chat, '--config', str(config_path)]), \
-             patch('sys.stdout', new_callable=StringIO) as mock_stdout, \
-             patch('sys.stderr', new_callable=StringIO) as mock_stderr:
-            
+        with patch(
+            "telegram_download_chat.cli.TelegramChatDownloader", return_value=mock_downloader
+        ) as mock_tg_class, patch("telegram_download_chat.paths.get_app_dir", return_value=tmp_path), patch(
+            "sys.argv", ["script.py", test_chat, "--config", str(config_path)]
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout, patch(
+            "sys.stderr", new_callable=StringIO
+        ) as mock_stderr:
+
             # Import here to ensure patches are in place
             from telegram_download_chat.cli import main
-            
+
             # Run the main function
             print("\n=== Calling main() ===")
             result = 1
@@ -369,17 +390,17 @@ class TestCLIExecution:
                 print(f"main() returned: {result}")
             except Exception as e:
                 print(f"Exception in main(): {str(e)}")
-                
+
             # Capture output
             stdout = mock_stdout.getvalue()
             stderr = mock_stderr.getvalue()
-            
+
             # Print captured output for debugging
             print("\n=== Captured STDOUT ===")
             print(stdout)
             print("\n=== Captured STDERR ===")
             print(stderr)
-            
+
             # Print mock call information
             print("\n=== Mock Calls ===")
             print(f"TelegramChatDownloader calls: {mock_tg_class.mock_calls}")
@@ -387,10 +408,10 @@ class TestCLIExecution:
             print(f"get_entity_name calls: {mock_downloader.get_entity_name.mock_calls}")
             print(f"save_messages called: {mock_downloader.save_messages.called}")
             print(f"close called: {mock_downloader.close.called}")
-            
+
             # Verify the result
             assert result == 0, f"Expected return code 0, got {result}"
-            
+
             # Verify the downloader was used correctly
             mock_tg_class.assert_called_once()
             mock_downloader.connect.assert_called_once()
@@ -398,61 +419,61 @@ class TestCLIExecution:
             mock_downloader.get_entity_name.assert_called_once_with(test_chat)
             mock_downloader.save_messages.assert_called_once()
             mock_downloader.close.assert_called_once()
-            
+
             # Verify output file was created
             output_file = tmp_path / f"{test_chat}.json"
             assert output_file.exists(), f"Expected output file {output_file} to exist"
 
-    @patch('telegram_download_chat.core.print')
-    @patch('telegram_download_chat.core.Path')
+    @patch("telegram_download_chat.core.print")
+    @patch("telegram_download_chat.core.Path")
     def test_load_config(self, mock_path, mock_print):
         """Test loading configuration from a file."""
         # Mock the config file content
-        config_content = '''
+        config_content = """
         settings:
           default_output: test_output.json
           fetch_limit: 100
-        '''
-        
+        """
+
         # Create a mock file object
         m = mock_open(read_data=config_content)
-        
+
         # Set up the mock Path object
         mock_path.return_value.exists.return_value = True
-        
+
         # Patch the open function
-        with patch('builtins.open', m):
+        with patch("builtins.open", m):
             # Create a downloader instance
             downloader = TelegramChatDownloader()
-        
+
             # Verify the config was loaded correctly
-            assert 'settings' in downloader.config
-            assert downloader.config['settings']['default_output'] == 'test_output.json'
-            assert downloader.config['settings']['fetch_limit'] == 100
-        
+            assert "settings" in downloader.config
+            assert downloader.config["settings"]["default_output"] == "test_output.json"
+            assert downloader.config["settings"]["fetch_limit"] == 100
+
         # Verify the file was opened with the correct parameters
         # We use assert_any_call instead of assert_called_once since the file might be opened multiple times
-        m.assert_any_call(mock_path.return_value, 'r', encoding='utf-8')
+        m.assert_any_call(mock_path.return_value, "r", encoding="utf-8")
         assert m().read.call_count >= 1  # At least one read should have happened
-
 
 
 def test_make_serializable():
     """Test making objects JSON serializable."""
     from datetime import datetime
+
     from telegram_download_chat.core import TelegramChatDownloader
-    
+
     downloader = TelegramChatDownloader()
-    
+
     # Test with datetime
     dt = datetime(2023, 1, 1, 12, 0, 0)
     # The make_serializable method returns datetime as 'YYYY-MM-DD HH:MM:SS' format
-    assert downloader.make_serializable(dt) == '2023-01-01 12:00:00'
-    
+    assert downloader.make_serializable(dt) == "2023-01-01 12:00:00"
+
     # Test with dictionary
-    data = {'key': 'value', 'nested': {'number': 123}}
+    data = {"key": "value", "nested": {"number": 123}}
     assert downloader.make_serializable(data) == data
-    
+
     # Test with list
     assert downloader.make_serializable([1, 2, 3]) == [1, 2, 3]
 
@@ -463,58 +484,60 @@ async def test_get_entity_name():
     # Create a mock client and set it on the downloader
     mock_client = AsyncMock()
     mock_entity = MagicMock()
-    mock_entity.title = 'Test Chat'
-    
+    mock_entity.title = "Test Chat"
+
     # Create a mock for the get_entity method
     async def mock_get_entity(identifier):
         return mock_entity
-    
+
     # Create downloader and set up mocks
     downloader = TelegramChatDownloader()
     downloader.client = mock_client
     downloader.get_entity = AsyncMock(side_effect=mock_get_entity)
     downloader.connect = AsyncMock()
-    
+
     # Test with a username
-    name = await downloader.get_entity_name('@testchat')
-    assert name == 'Test_Chat'
-    
+    name = await downloader.get_entity_name("@testchat")
+    assert name == "Test_Chat"
+
     # Verify get_entity was called with the correct argument
-    downloader.get_entity.assert_awaited_once_with('@testchat')
-    
+    downloader.get_entity.assert_awaited_once_with("@testchat")
+
     # Test with a URL
     downloader.get_entity.reset_mock()
-    name = await downloader.get_entity_name('https://t.me/testchat')
-    assert name == 'Test_Chat'
-    downloader.get_entity.assert_awaited_once_with('https://t.me/testchat')
+    name = await downloader.get_entity_name("https://t.me/testchat")
+    assert name == "Test_Chat"
+    downloader.get_entity.assert_awaited_once_with("https://t.me/testchat")
 
 
 def test_get_temp_file_path():
     """Test getting temporary file path."""
     from telegram_download_chat.core import TelegramChatDownloader
-    
+
     downloader = TelegramChatDownloader()
-    output_file = Path('test_output.json')
+    output_file = Path("test_output.json")
     temp_path = downloader.get_temp_file_path(output_file)
-    assert str(temp_path) == 'test_output.part.jsonl'
+    assert str(temp_path) == "test_output.part.jsonl"
 
 
 @pytest.mark.asyncio
 async def test_download_chat_with_limit():
     """Test downloading chat with a message limit."""
     import logging
+
     from telethon.tl.types import PeerChannel
+
     from telegram_download_chat.core import TelegramChatDownloader
-    
+
     # Set up logging
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)
-    
+
     # Create a mock client with proper async methods
     mock_client = AsyncMock()
     # is_connected is a property, not a coroutine
     type(mock_client).is_connected = property(lambda s: False)
-    
+
     # Create test messages
     test_messages = [
         MagicMock(
@@ -523,56 +546,52 @@ async def test_download_chat_with_limit():
             message=f"Test message {i}",
             date=None,
             sender_id=1,
-            peer_id=PeerChannel(channel_id=12345)
+            peer_id=PeerChannel(channel_id=12345),
         )
         for i in range(1, 101)
     ]
-    
+
     # Mock the client's __call__ method to return our mock messages
-    mock_client.return_value = MagicMock(
-        messages=test_messages,
-        users=[],
-        chats=[]
-    )
-    
+    mock_client.return_value = MagicMock(messages=test_messages, users=[], chats=[])
+
     # Create downloader and set the mock client
     downloader = TelegramChatDownloader()
     downloader.client = mock_client
     downloader.logger = logger
     downloader.connect = AsyncMock()
-    
+
     # Mock get_entity to return a basic entity
     mock_entity = MagicMock(id=12345, title="Test Chat")
     downloader.client.get_entity = AsyncMock(return_value=mock_entity)
-    
+
     # Create a function to handle GetHistoryRequest with limit
     def mock_get_history_request(*args, **kwargs):
-        limit = kwargs.get('limit', 100)
+        limit = kwargs.get("limit", 100)
         mock_result = MagicMock()
         mock_result.messages = test_messages[:limit]
         mock_result.users = []
         mock_result.chats = []
         return mock_result
-    
+
     # Patch the GetHistoryRequest to use our mock function
-    with patch('telethon.tl.functions.messages.GetHistoryRequest', side_effect=mock_get_history_request):
+    with patch("telethon.tl.functions.messages.GetHistoryRequest", side_effect=mock_get_history_request):
         # Test with limit
         logger.debug("Starting download_chat with limit=10")
         messages = await downloader.download_chat("test_chat", total_limit=10)
-        
+
         logger.debug(f"Downloaded {len(messages)} messages")
         if messages:
-            first_id = messages[0].get('id') if isinstance(messages[0], dict) else messages[0].id
-            last_id = messages[-1].get('id') if isinstance(messages[-1], dict) else messages[-1].id
+            first_id = messages[0].get("id") if isinstance(messages[0], dict) else messages[0].id
+            last_id = messages[-1].get("id") if isinstance(messages[-1], dict) else messages[-1].id
             logger.debug(f"First message ID: {first_id}")
             logger.debug(f"Last message ID: {last_id}")
-        
+
         assert len(messages) == 10, f"Expected 10 messages, got {len(messages)}"
         if messages:
             first_msg = messages[0]
-            first_id = first_msg.id if hasattr(first_msg, 'id') else first_msg.get('id')
+            first_id = first_msg.id if hasattr(first_msg, "id") else first_msg.get("id")
             last_msg = messages[-1]
-            last_id = last_msg.id if hasattr(last_msg, 'id') else last_msg.get('id')
+            last_id = last_msg.id if hasattr(last_msg, "id") else last_msg.get("id")
             assert first_id == 1, f"Expected first message ID to be 1, got {first_id}"
             assert last_id == 10, f"Expected last message ID to be 10, got {last_id}"
 
@@ -584,34 +603,32 @@ async def test_save_messages():
     import tempfile
     from pathlib import Path
     from unittest.mock import MagicMock
+
     from telegram_download_chat.core import TelegramChatDownloader
-    
+
     # Create test message data
-    test_message_data = [
-        {"id": 1, "message": "Test message 1"},
-        {"id": 2, "message": "Test message 2"}
-    ]
-    
+    test_message_data = [{"id": 1, "message": "Test message 1"}, {"id": 2, "message": "Test message 2"}]
+
     # Create mock Message objects with to_dict method
     test_messages = []
     for msg_data in test_message_data:
         msg = MagicMock()
         msg.to_dict.return_value = msg_data
         test_messages.append(msg)
-    
+
     # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.json') as tmp_file:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp_file:
         output_file = Path(tmp_file.name)
-    
+
     try:
         # Create downloader and save messages
         downloader = TelegramChatDownloader()
         downloader.logger = MagicMock()  # Mock the logger
-        await downloader.save_messages(test_messages, str(output_file))
-        
+        await downloader.save_messages(test_messages, str(output_file), sort_order="desc")
+
         # Verify file was created and contains correct data
         assert output_file.exists()
-        with open(output_file, 'r', encoding='utf-8') as f:
+        with open(output_file, "r", encoding="utf-8") as f:
             saved_data = json.load(f)
             assert saved_data == test_message_data
     finally:
@@ -624,49 +641,49 @@ async def test_save_messages():
 async def test_connect_and_disconnect():
     """Test connecting to and disconnecting from Telegram."""
     import os
-    from unittest.mock import patch, MagicMock, AsyncMock
+    from unittest.mock import AsyncMock, MagicMock, patch
+
     from telegram_download_chat.core import TelegramChatDownloader
-    
+
     # Create a mock client with proper async methods
     mock_client = AsyncMock()
     mock_client.start = AsyncMock()
     mock_client.disconnect = AsyncMock()
     # is_connected is a method that returns a boolean
     mock_client.is_connected = MagicMock(return_value=True)
-    
+
     # Create a mock client class that returns our mock client
     mock_client_class = MagicMock(return_value=mock_client)
-    
+
     # Patch the environment variables and TelegramClient
-    with patch.dict(os.environ, {
-        'TELEGRAM_API_ID': 'test_api_id',
-        'TELEGRAM_API_HASH': 'test_api_hash'
-    }), patch('telegram_download_chat.core.TelegramClient', new=mock_client_class):
+    with patch.dict(os.environ, {"TELEGRAM_API_ID": "test_api_id", "TELEGRAM_API_HASH": "test_api_hash"}), patch(
+        "telegram_download_chat.core.TelegramClient", new=mock_client_class
+    ):
         # Create downloader
         downloader = TelegramChatDownloader()
-        
+
         # Mock the config to avoid file operations
         downloader.config = {
-            'settings': {
-                'api_id': 'test_api_id',
-                'api_hash': 'test_api_hash',
-                'session_name': 'test_session',
-                'request_retries': 3,
-                'request_delay': 1
+            "settings": {
+                "api_id": "test_api_id",
+                "api_hash": "test_api_hash",
+                "session_name": "test_session",
+                "request_retries": 3,
+                "request_delay": 1,
             }
         }
-        
+
         # Test connect
         await downloader.connect()
-        
+
         # Verify client was created and started
         mock_client_class.assert_called_once()
         mock_client.start.assert_awaited_once()
         assert downloader.client is not None
-        
+
         # Test disconnect
         await downloader.close()
-        
+
         # Verify client was disconnected
         mock_client.disconnect.assert_awaited_once()
         assert downloader.client is None
@@ -675,36 +692,49 @@ async def test_connect_and_disconnect():
 @pytest.mark.asyncio
 async def test_download_chat_error_handling():
     """Test that download_chat properly propagates errors from get_entity."""
-    from unittest.mock import patch, MagicMock, AsyncMock
+    from unittest.mock import AsyncMock, MagicMock, patch
+
     from telegram_download_chat.core import TelegramChatDownloader
-    
+
     # Create a mock client
     mock_client = AsyncMock()
     mock_client.is_connected = AsyncMock(return_value=False)
-    
+
     # Create downloader and set up mocks
-    with patch('telegram_download_chat.core.TelegramChatDownloader._setup_logging'):
+    with patch("telegram_download_chat.core.TelegramChatDownloader._setup_logging"):
         downloader = TelegramChatDownloader()
-    
+
     downloader.client = mock_client
     downloader.connect = AsyncMock()
     downloader.logger = MagicMock()
-    
+
     # Create a mock for get_entity that raises a ValueError
     error_msg = "Cannot find any entity corresponding to 'test_chat'"
     mock_get_entity = AsyncMock(side_effect=ValueError(error_msg))
-    
+
     # Replace the get_entity method with our mock
-    with patch.object(downloader, 'get_entity', new=mock_get_entity):
+    with patch.object(downloader, "get_entity", new=mock_get_entity):
         # Test that the error is properly propagated
         with pytest.raises(ValueError, match=error_msg) as exc_info:
             await downloader.download_chat("test_chat")
-        
+
         # Verify the error message is correct
         assert str(exc_info.value) == error_msg
-    
+
     # Verify that get_entity was called with the correct argument
     mock_get_entity.assert_called_once_with("test_chat")
-    
+
     # Verify that no error was logged (since the error is propagated, not logged)
     assert not downloader.logger.error.called, "Expected no error to be logged since the error is propagated"
+
+
+def test_prepare_messages_for_txt_ordering():
+    downloader = TelegramChatDownloader()
+    messages = [
+        {"id": 1, "date": "2025-07-01 10:00:00+00:00", "text": "parent"},
+        {"id": 2, "date": "2025-07-01 10:05:00+00:00", "text": "reply1", "reply_to": {"reply_to_msg_id": 1}},
+        {"id": 3, "date": "2025-07-01 10:10:00+00:00", "text": "reply2", "reply_to": {"reply_to_msg_id": 1}},
+    ]
+
+    ordered = downloader.prepare_messages_for_txt(messages, "desc")
+    assert [m["id"] for m in ordered] == [1, 3, 2]


### PR DESCRIPTION
## Summary
- add `--sort` CLI option to control ordering by date
- include replied-to messages before replies in TXT output
- expose new helper `prepare_messages_for_txt`
- update documentation and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864417068e8832cad09086f1ea012f0