### PR TITLE
Fix reply ordering

### DIFF
--- a/src/telegram_download_chat/core.py
+++ b/src/telegram_download_chat/core.py
@@ -659,10 +659,17 @@ class TelegramChatDownloader:
     def prepare_messages_for_txt(
         self, messages: List[Dict[str, Any]], sort_order: str = "desc"
     ) -> List[Dict[str, Any]]:
-        """Sort messages and place replied-to messages before replies."""
+        """Sort messages and group replies with their parents.
+
+        When ``sort_order`` is ``"asc"`` messages are ordered from oldest to
+        newest with each replied-to message followed by its replies. When
+        ``sort_order`` is ``"desc"`` the order is reversed but replied-to
+        messages still appear before their replies.
+        """
+
         from datetime import datetime
 
-        def parse_dt(msg):
+        def parse_dt(msg: Dict[str, Any]) -> datetime:
             date_str = msg.get("date")
             if not date_str:
                 return datetime.min
@@ -671,42 +678,35 @@ class TelegramChatDownloader:
             except Exception:
                 return datetime.min
 
-        sorted_msgs = sorted(messages, key=parse_dt, reverse=(sort_order == "desc"))
-        id_map = {m.get("id"): m for m in sorted_msgs if m.get("id") is not None}
-        inserted = set()
-        result = []
+        # Build mapping of message id -> message and tree of replies
+        id_map: Dict[Any, Dict[str, Any]] = {
+            m.get("id"): m for m in messages if m.get("id") is not None
+        }
+        children: Dict[Any, List[Dict[str, Any]]] = {}
+        roots: List[Dict[str, Any]] = []
 
-        for msg in sorted_msgs:
-            msg_id = msg.get("id")
-            if msg_id in inserted:
-                continue
+        for msg in messages:
+            reply = msg.get("reply_to") or {}
+            reply_id = reply.get("reply_to_msg_id") or msg.get("reply_to_msg_id")
+            if reply_id and reply_id in id_map:
+                children.setdefault(reply_id, []).append(msg)
+            else:
+                roots.append(msg)
 
-            chain = []
-            current = msg
-            visited = set()
-            while True:
-                reply = current.get("reply_to") or {}
-                reply_id = reply.get("reply_to_msg_id") or current.get("reply_to_msg_id")
-                if not reply_id or reply_id in visited:
-                    break
-                visited.add(reply_id)
-                parent = id_map.get(reply_id)
-                if not parent or parent.get("id") in inserted:
-                    break
-                chain.append(parent)
-                current = parent
+        def sort_msgs(msgs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+            return sorted(msgs, key=parse_dt, reverse=(sort_order == "desc"))
 
-            for parent in reversed(chain):
-                pid = parent.get("id")
-                if pid not in inserted:
-                    result.append(parent)
-                    inserted.add(pid)
+        def traverse(msg: Dict[str, Any]) -> List[Dict[str, Any]]:
+            ordered = [msg]
+            for child in sort_msgs(children.get(msg.get("id"), [])):
+                ordered.extend(traverse(child))
+            return ordered
 
-            result.append(msg)
-            if msg_id is not None:
-                inserted.add(msg_id)
+        ordered_messages: List[Dict[str, Any]] = []
+        for root in sort_msgs(roots):
+            ordered_messages.extend(traverse(root))
 
-        return result
+        return ordered_messages
 
     async def save_messages_as_txt(
         self, messages: List[Dict[str, Any]], txt_path: Path, sort_order: str = "desc"

--- a/tests/test_telegram_download_chat.py
+++ b/tests/test_telegram_download_chat.py
@@ -738,3 +738,23 @@ def test_prepare_messages_for_txt_ordering():
 
     ordered = downloader.prepare_messages_for_txt(messages, "desc")
     assert [m["id"] for m in ordered] == [1, 3, 2]
+
+
+def test_prepare_messages_for_txt_ordering_asc():
+    downloader = TelegramChatDownloader()
+    with open("tests/fixtures/replies.json", "r", encoding="utf-8") as f:
+        messages = json.load(f)
+
+    ordered = downloader.prepare_messages_for_txt(messages, "asc")
+    assert [m["id"] for m in ordered] == [
+        340522,
+        340525,
+        340527,
+        340529,
+        340523,
+        340532,
+        340526,
+        340528,
+        340530,
+        340531,
+    ]


### PR DESCRIPTION
## Summary
- group replies with parent messages in TXT preparation
- add test for ascending order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688138783628832c9bdc6e83c33f93d2