### PR TITLE
Add --from and --last-days options

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ telegram-download-chat folder:folder_name
 # Download messages until a specific date (YYYY-MM-DD)
 telegram-download-chat username --until 2025-05-01
 
+# Download last N days of messages from a specific date
+telegram-download-chat username --from 2025-06-05 --last-days 1
+
 # Filter messages by specific user
 telegram-download-chat group_username --user 123456
 
@@ -177,7 +180,8 @@ telegram-download-chat --show-config
 ### Command Line Options
 
 ```
-usage: telegram-download-chat [-h] [-o OUTPUT] [--limit LIMIT] [--until DATE] [--subchat SUBCHAT]
+usage: telegram-download-chat [-h] [-o OUTPUT] [--limit LIMIT] [--from DATE] [--last-days DAYS]
+                            [--until DATE] [--subchat SUBCHAT]
                             [--subchat-name NAME] [--user USER] [--config CONFIG] [--debug]
                             [--sort {asc,desc}] [--show-config] [-v]
                             [chat]
@@ -191,6 +195,8 @@ options:
   -h, --help            show this help message and exit
   -o, --output OUTPUT    Output file path (default: chat_<chat_id>.json)
   -l, --limit LIMIT     Maximum number of messages to download (default: 0 - no limit)
+  --from DATE           Base date for --last-days (format: YYYY-MM-DD)
+  --last-days DAYS      Number of days back from --from (or today) to download
   --until DATE          Only download messages until this date (format: YYYY-MM-DD)
   --subchat SUBCHAT     Filter messages by thread/reply chain (message ID or URL)
   --subchat-name NAME   Custom name for subchat directory
@@ -223,7 +229,7 @@ This feature is particularly useful for:
 - Processing your full Telegram data export
 - Extracting specific conversations from the export
 - Converting the export to a more readable format
-- Filtering messages by user or date range (using `--until`)
+- Filtering messages by user or date range (using `--until` or `--last-days`)
 
 The tool will process the archive and generate both JSON and TXT files with the exported messages.
 

--- a/src/telegram_download_chat/cli.py
+++ b/src/telegram_download_chat/cli.py
@@ -4,7 +4,9 @@
 # Suppress pkg_resources deprecation warning
 import warnings
 
-warnings.filterwarnings("ignore", message="pkg_resources is deprecated", category=DeprecationWarning)
+warnings.filterwarnings(
+    "ignore", message="pkg_resources is deprecated", category=DeprecationWarning
+)
 
 import argparse
 import asyncio
@@ -44,34 +46,89 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Download Telegram chat history to JSON")
-
-    parser.add_argument("chat", nargs="?", help="Chat identifier (username, phone number, or chat ID)")
-    parser.add_argument("-o", "--output", help="Output file path (default: <chat_name>.json)", default=None)
-    parser.add_argument(
-        "-l", "--limit", type=int, default=0, help="Maximum number of messages to download (default: 0 - no limit)"
+    parser = argparse.ArgumentParser(
+        description="Download Telegram chat history to JSON"
     )
-    parser.add_argument("-c", "--config", default=None, help="Path to config file (default: OS-specific location)")
+
+    parser.add_argument(
+        "chat", nargs="?", help="Chat identifier (username, phone number, or chat ID)"
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: <chat_name>.json)",
+        default=None,
+    )
+    parser.add_argument(
+        "-l",
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum number of messages to download (default: 0 - no limit)",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=None,
+        help="Path to config file (default: OS-specific location)",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument(
-        "--show-config", action="store_true", help="Show the current configuration file location and exit"
+        "--show-config",
+        action="store_true",
+        help="Show the current configuration file location and exit",
     )
     parser.add_argument(
-        "--subchat", type=str, help="Filter messages for txt by subchat id or URL (only for JSON to TXT conversion)"
+        "--subchat",
+        type=str,
+        help="Filter messages for txt by subchat id or URL (only for JSON to TXT conversion)",
     )
     parser.add_argument(
-        "--subchat-name", type=str, help="Name for the subchat directory (default: subchat_<subchat_id>)"
+        "--subchat-name",
+        type=str,
+        help="Name for the subchat directory (default: subchat_<subchat_id>)",
     )
-    parser.add_argument("--user", type=str, help="Filter messages by sender ID (e.g., 12345 or user12345)")
-    parser.add_argument("--until", type=str, help="Only download messages until this date (format: YYYY-MM-DD)")
-    parser.add_argument("--split", choices=["month", "year"], help="Split output files by month or year")
-    parser.add_argument("--sort", choices=["asc", "desc"], default="desc", help="Sort messages by date (default: desc)")
-    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "--user",
+        type=str,
+        help="Filter messages by sender ID (e.g., 12345 or user12345)",
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_date",
+        type=str,
+        help="Base date for --last-days calculation (format: YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--last-days",
+        dest="last_days",
+        type=int,
+        help="Number of days back from --from (or today) to download",
+    )
+    parser.add_argument(
+        "--until",
+        type=str,
+        help="Only download messages until this date (format: YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--split", choices=["month", "year"], help="Split output files by month or year"
+    )
+    parser.add_argument(
+        "--sort",
+        choices=["asc", "desc"],
+        default="desc",
+        help="Sort messages by date (default: desc)",
+    )
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
 
     return parser.parse_args()
 
 
-def split_messages_by_date(messages: List[Dict[str, Any]], split_by: str) -> Dict[str, List[Dict[str, Any]]]:
+def split_messages_by_date(
+    messages: List[Dict[str, Any]], split_by: str
+) -> Dict[str, List[Dict[str, Any]]]:
     """Split messages by month or year based on message date.
 
     Args:
@@ -110,7 +167,9 @@ def split_messages_by_date(messages: List[Dict[str, Any]], split_by: str) -> Dic
     return split_messages
 
 
-def filter_messages_by_subchat(messages: List[Dict[str, Any]], subchat_id: str) -> List[Dict[str, Any]]:
+def filter_messages_by_subchat(
+    messages: List[Dict[str, Any]], subchat_id: str
+) -> List[Dict[str, Any]]:
     """Filter messages by reply_to_msg_id or reply_to_top_id.
 
     Args:
@@ -144,9 +203,9 @@ def filter_messages_by_subchat(messages: List[Dict[str, Any]], subchat_id: str) 
             continue
 
         # Check both reply_to_msg_id and reply_to_top_id
-        if str(reply_to.get("reply_to_msg_id")) == str(target_id) or str(reply_to.get("reply_to_top_id")) == str(
-            target_id
-        ):
+        if str(reply_to.get("reply_to_msg_id")) == str(target_id) or str(
+            reply_to.get("reply_to_top_id")
+        ) == str(target_id):
             filtered.append(msg)
 
     return filtered
@@ -163,7 +222,9 @@ async def _run_with_status(task_coro: Any, logger: logging.Logger, message: str 
 
     try:
         # Wait for either the task to complete or 2 seconds to elapse
-        done, pending = await asyncio.wait([task], timeout=2.0, return_when=asyncio.FIRST_COMPLETED)
+        done, pending = await asyncio.wait(
+            [task], timeout=2.0, return_when=asyncio.FIRST_COMPLETED
+        )
 
         # If task is still pending after timeout, show status message
         if pending and not message:
@@ -178,17 +239,27 @@ async def _run_with_status(task_coro: Any, logger: logging.Logger, message: str 
 
 
 async def save_messages_with_status(
-    downloader: TelegramChatDownloader, messages: List[Any], output_file: str, sort_order: str = "desc"
+    downloader: TelegramChatDownloader,
+    messages: List[Any],
+    output_file: str,
+    sort_order: str = "desc",
 ) -> None:
     return await _run_with_status(
-        downloader.save_messages(messages, output_file, sort_order=sort_order), downloader.logger
+        downloader.save_messages(messages, output_file, sort_order=sort_order),
+        downloader.logger,
     )
 
 
 async def save_txt_with_status(
-    downloader: TelegramChatDownloader, messages: List[Any], txt_file: Path, sort_order: str = "desc"
+    downloader: TelegramChatDownloader,
+    messages: List[Any],
+    txt_file: Path,
+    sort_order: str = "desc",
 ) -> int:
-    return await _run_with_status(downloader.save_messages_as_txt(messages, txt_file, sort_order), downloader.logger)
+    return await _run_with_status(
+        downloader.save_messages_as_txt(messages, txt_file, sort_order),
+        downloader.logger,
+    )
 
 
 async def process_chat_download(
@@ -201,14 +272,20 @@ async def process_chat_download(
 
     safe_chat_name = await downloader.get_entity_name(chat_identifier)
     if not safe_chat_name:
-        downloader.logger.error(f"Failed to get entity name for chat: {chat_identifier}")
+        downloader.logger.error(
+            f"Failed to get entity name for chat: {chat_identifier}"
+        )
         return 1
 
     output_file = args.output
     if not output_file or output_dir != Path(output_file).parent:
         output_file = str(output_dir / f"{safe_chat_name}.json")
         if args.subchat:
-            output_file = str(Path(output_file).with_stem(f"{Path(output_file).stem}_subchat_{args.subchat}"))
+            output_file = str(
+                Path(output_file).with_stem(
+                    f"{Path(output_file).stem}_subchat_{args.subchat}"
+                )
+            )
 
     download_kwargs = {
         "chat_id": chat_identifier,
@@ -227,7 +304,9 @@ async def process_chat_download(
 
     if args.subchat:
         messages = filter_messages_by_subchat(messages, args.subchat)
-        downloader.logger.info(f"Filtered to {len(messages)} messages in subchat {args.subchat}")
+        downloader.logger.info(
+            f"Filtered to {len(messages)} messages in subchat {args.subchat}"
+        )
 
     if not messages:
         downloader.logger.warning("No messages to save")
@@ -238,8 +317,12 @@ async def process_chat_download(
             split_messages = split_messages_by_date(messages, args.split)
 
             if not split_messages:
-                downloader.logger.warning("No messages with valid dates found for splitting")
-                await save_messages_with_status(downloader, messages, output_file, args.sort)
+                downloader.logger.warning(
+                    "No messages with valid dates found for splitting"
+                )
+                await save_messages_with_status(
+                    downloader, messages, output_file, args.sort
+                )
             else:
                 output_path = Path(output_file)
                 base_name = output_path.stem
@@ -247,12 +330,20 @@ async def process_chat_download(
 
                 for date_key, msgs in split_messages.items():
                     split_file = output_path.with_name(f"{base_name}_{date_key}{ext}")
-                    await save_messages_with_status(downloader, msgs, str(split_file), args.sort)
-                    downloader.logger.info(f"Saved {len(msgs)} messages to {split_file}")
+                    await save_messages_with_status(
+                        downloader, msgs, str(split_file), args.sort
+                    )
+                    downloader.logger.info(
+                        f"Saved {len(msgs)} messages to {split_file}"
+                    )
 
-                downloader.logger.info(f"Saved {len(split_messages)} split files in {output_path.parent}")
+                downloader.logger.info(
+                    f"Saved {len(split_messages)} split files in {output_path.parent}"
+                )
         else:
-            await save_messages_with_status(downloader, messages, output_file, args.sort)
+            await save_messages_with_status(
+                downloader, messages, output_file, args.sort
+            )
 
     except Exception as e:
         downloader.logger.error(f"Failed to save messages: {e}", exc_info=args.debug)
@@ -273,7 +364,9 @@ async def async_main():
     try:
         # Show config path and exit if requested
         if args.show_config:
-            config_path = Path(args.config) if args.config else get_default_config_path()
+            config_path = (
+                Path(args.config) if args.config else get_default_config_path()
+            )
             downloader.logger.info(f"Configuration file: {config_path}")
             if config_path.exists():
                 downloader.logger.info("\nCurrent configuration:")
@@ -283,13 +376,30 @@ async def async_main():
                 except Exception as e:
                     downloader.logger.error(f"\nError reading config file: {e}")
             else:
-                downloader.logger.info("\nConfiguration file does not exist yet. It will be created on first run.")
+                downloader.logger.info(
+                    "\nConfiguration file does not exist yet. It will be created on first run."
+                )
             return 0
 
         # Set debug log level if requested
         if args.debug:
             downloader.logger.setLevel(logging.DEBUG)
             downloader.logger.debug("Debug logging enabled")
+
+        # Calculate --until from --last-days and --from if provided
+        if args.last_days is not None:
+            from datetime import datetime, timedelta
+
+            base_str = args.from_date or datetime.utcnow().strftime("%Y-%m-%d")
+            try:
+                base_date = datetime.strptime(base_str, "%Y-%m-%d")
+            except ValueError:
+                downloader.logger.error("Invalid date format for --from")
+                return 1
+
+            args.until = (base_date - timedelta(days=args.last_days)).strftime(
+                "%Y-%m-%d"
+            )
 
         if not args.chat:
             downloader.logger.error("Chat identifier is required")
@@ -300,8 +410,12 @@ async def async_main():
             await downloader.connect()
         except Exception as e:
             downloader.logger.error(f"Failed to connect to Telegram: {e}")
-            downloader.logger.info("\nPlease make sure you have entered your API credentials in the config file.")
-            downloader.logger.info("You can edit the config file at: %s", get_default_config_path())
+            downloader.logger.info(
+                "\nPlease make sure you have entered your API credentials in the config file."
+            )
+            downloader.logger.info(
+                "You can edit the config file at: %s", get_default_config_path()
+            )
             return 1
 
         # Set up stop file for inter-process communication using fixed name
@@ -311,7 +425,9 @@ async def async_main():
         downloader.set_stop_file(str(stop_file))
 
         # Get downloads directory from config
-        downloads_dir = Path(downloader.config.get("settings", {}).get("save_path", get_downloads_dir()))
+        downloads_dir = Path(
+            downloader.config.get("settings", {}).get("save_path", get_downloads_dir())
+        )
         downloads_dir.mkdir(parents=True, exist_ok=True)
 
         # Handle JSON conversion mode if --subchat is provided without --json
@@ -336,14 +452,24 @@ async def async_main():
                 messages = json.load(f)
 
             # Check if messages is a dictionary with 'about' and 'chats' keys
-            if isinstance(messages, dict) and "about" in messages and "chats" in messages:
-                messages = downloader.convert_archive_to_messages(messages, user_filter=args.user)
+            if (
+                isinstance(messages, dict)
+                and "about" in messages
+                and "chats" in messages
+            ):
+                messages = downloader.convert_archive_to_messages(
+                    messages, user_filter=args.user
+                )
 
             txt_path = Path(json_path).with_suffix(".txt")
 
             # If user filter is specified, add it to the filename
             if args.user:
-                user_id = args.user.replace("user", "") if args.user.startswith("user") else args.user
+                user_id = (
+                    args.user.replace("user", "")
+                    if args.user.startswith("user")
+                    else args.user
+                )
                 txt_path = txt_path.with_stem(f"{txt_path.stem}_user_{user_id}")
 
             # Apply subchat filter if specified
@@ -351,18 +477,27 @@ async def async_main():
                 messages = filter_messages_by_subchat(messages, args.subchat)
                 # Use subchat_name directly in filename
                 txt_path = (
-                    downloads_dir / f"{args.subchat_name or f'{txt_path.stem}_subchat_{args.subchat}'}{txt_path.suffix}"
+                    downloads_dir
+                    / f"{args.subchat_name or f'{txt_path.stem}_subchat_{args.subchat}'}{txt_path.suffix}"
                 )
-                downloader.logger.info(f"Filtered to {len(messages)} messages in subchat {args.subchat}")
+                downloader.logger.info(
+                    f"Filtered to {len(messages)} messages in subchat {args.subchat}"
+                )
 
             # Handle message splitting if requested
             if args.split:
                 split_messages = split_messages_by_date(messages, args.split)
                 if not split_messages:
-                    downloader.logger.warning("No messages with valid dates found for splitting")
-                    saved = await save_txt_with_status(downloader, messages, txt_path, args.sort)
+                    downloader.logger.warning(
+                        "No messages with valid dates found for splitting"
+                    )
+                    saved = await save_txt_with_status(
+                        downloader, messages, txt_path, args.sort
+                    )
                     saved_relative = get_relative_to_downloads_dir(txt_path)
-                    downloader.logger.info(f"Saved {saved} messages to {saved_relative}")
+                    downloader.logger.info(
+                        f"Saved {saved} messages to {saved_relative}"
+                    )
                 else:
                     # Save each group to a separate file
                     base_name = txt_path.stem
@@ -370,13 +505,21 @@ async def async_main():
 
                     for date_key, msgs in split_messages.items():
                         split_file = txt_path.with_name(f"{base_name}_{date_key}{ext}")
-                        saved = await save_txt_with_status(downloader, msgs, split_file, args.sort)
+                        saved = await save_txt_with_status(
+                            downloader, msgs, split_file, args.sort
+                        )
                         saved_relative = get_relative_to_downloads_dir(split_file)
-                        downloader.logger.info(f"Saved {saved} messages to {saved_relative}")
+                        downloader.logger.info(
+                            f"Saved {saved} messages to {saved_relative}"
+                        )
 
-                    downloader.logger.info(f"Saved {len(split_messages)} split files in {txt_path.parent}")
+                    downloader.logger.info(
+                        f"Saved {len(split_messages)} split files in {txt_path.parent}"
+                    )
             else:
-                saved = await save_txt_with_status(downloader, messages, txt_path, args.sort)
+                saved = await save_txt_with_status(
+                    downloader, messages, txt_path, args.sort
+                )
                 saved_relative = get_relative_to_downloads_dir(txt_path)
                 downloader.logger.info(f"Saved {saved} messages to {saved_relative}")
 
@@ -389,7 +532,10 @@ async def async_main():
             folders = await downloader.list_folders()
             target = None
             for f in folders:
-                if getattr(getattr(f, "title"), "text", "") == folder_name:
+                title = getattr(f, "title", "")
+                if hasattr(title, "text"):
+                    title = title.text
+                if title == folder_name:
                     target = f
                     break
             if not target:
@@ -439,7 +585,9 @@ def main() -> int:
             gui_main()
             return 0
         except ImportError as e:
-            print("GUI dependencies not installed. Please install with: pip install 'telegram-download-chat[gui]'")
+            print(
+                "GUI dependencies not installed. Please install with: pip install 'telegram-download-chat[gui]'"
+            )
             print(e)
             return 1
         except Exception as e:


### PR DESCRIPTION
## Summary
- add `--from` and `--last-days` CLI arguments
- compute `--until` when using `--last-days`
- support strings for folder titles
- expose new options in GUI
- update settings saving/loading logic
- document new usage in README
- extend tests for new arguments

## Testing
- `isort src/telegram_download_chat/cli.py src/telegram_download_chat/gui/tabs/download_tab.py tests/test_telegram_download_chat.py`
- `black src/telegram_download_chat/cli.py src/telegram_download_chat/gui/tabs/download_tab.py tests/test_telegram_download_chat.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68814d8ce7ec832c91d84575abcaca8d