### PR TITLE
Fix CLI exception logging

### DIFF
--- a/src/telegram_download_chat/cli/__init__.py
+++ b/src/telegram_download_chat/cli/__init__.py
@@ -8,7 +8,6 @@ import logging
 import signal
 import sys
 import tempfile
-import traceback
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -154,8 +153,7 @@ async def async_main() -> int:
         return await download_chat(ctx, downloader, args, downloads_dir)
 
     except Exception as e:  # pragma: no cover - just logging
-        downloader.logger.error(f"An error occurred: {e}", exc_info=args.debug)
-        downloader.logger.error(traceback.format_exc())
+        downloader.logger.exception(f"An error occurred: {e}")
         return 1
     finally:
         _downloader_ctx = None

--- a/src/telegram_download_chat/cli/commands.py
+++ b/src/telegram_download_chat/cli/commands.py
@@ -185,7 +185,7 @@ async def process_chat_download(
                 downloader, messages, output_file, args.sort
             )
     except Exception as e:
-        downloader.logger.error(f"Failed to save messages: {e}", exc_info=args.debug)
+        downloader.logger.exception(f"Failed to save messages: {e}")
         return 1
 
     return 0


### PR DESCRIPTION
## Summary
- use `logger.exception` instead of `logger.error(..., exc_info=args.debug)`
- remove unused import
- keep CLI error stack traces consistent

## Testing
- `pre-commit run --files src/telegram_download_chat/cli/commands.py src/telegram_download_chat/cli/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688224afdfdc832cbe9357399d641ff1