### PR TITLE
Move TelegramAuth to core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ src/telegram_download_chat/
 ├── core/                     # Core downloader package with mixins
 │   ├── downloader.py         # TelegramChatDownloader
 │   ├── auth.py               # Authentication helpers
+│   ├── auth_utils.py         # TelegramAuth utilities
 │   ├── config.py             # Configuration helpers
 │   ├── download.py           # Chat downloading logic
 │   ├── entities.py           # Entity utilities
@@ -39,7 +40,6 @@ src/telegram_download_chat/
 │   └── utils/                # Utility modules
 │       ├── config.py         # Configuration management
 │       ├── file_utils.py     # File operations
-│       └── telegram_auth.py  # Telegram authentication
 │
 └── gui_app_.py              # Old GUI implementation (renamed)
 ├── cli/                     # Command line interface package

--- a/src/telegram_download_chat/core/__init__.py
+++ b/src/telegram_download_chat/core/__init__.py
@@ -2,7 +2,15 @@ from pathlib import Path
 
 from telethon import TelegramClient
 
+from .auth_utils import TelegramAuth, TelegramAuthError
 from .context import DownloaderContext
 from .downloader import TelegramChatDownloader
 
-__all__ = ["TelegramChatDownloader", "DownloaderContext", "Path", "TelegramClient"]
+__all__ = [
+    "TelegramChatDownloader",
+    "DownloaderContext",
+    "TelegramAuth",
+    "TelegramAuthError",
+    "Path",
+    "TelegramClient",
+]

--- a/src/telegram_download_chat/core/auth_utils.py
+++ b/src/telegram_download_chat/core/auth_utils.py
@@ -41,6 +41,7 @@ class TelegramAuth:
         self.session_path = str(session_path)
         self.client: Optional[TelegramClient] = None
         self._is_authenticated = False
+        self.phone_code_hash: Optional[str] = None
 
     async def initialize(self) -> None:
         """Initialize the Telegram client."""
@@ -58,7 +59,7 @@ class TelegramAuth:
             await self.client.connect()
             self._is_authenticated = await self.client.is_user_authorized()
 
-    async def request_code(self, phone: str) -> None:
+    async def request_code(self, phone: str) -> Optional[str]:
         """Request a login code from Telegram.
 
         Args:
@@ -81,7 +82,9 @@ class TelegramAuth:
 
             logger.debug("Sending code request...")
             result = await self.client.send_code_request(phone)
+            self.phone_code_hash = getattr(result, "phone_code_hash", None)
             logger.debug(f"Code request sent successfully: {result}")
+            return self.phone_code_hash
 
         except (
             PhoneNumberInvalidError,

--- a/src/telegram_download_chat/gui/auth/session_manager.py
+++ b/src/telegram_download_chat/gui/auth/session_manager.py
@@ -11,8 +11,8 @@ from telethon.errors import (
 )
 
 from ...core import TelegramChatDownloader
+from ...core.auth_utils import TelegramAuthError
 from ...paths import get_app_dir
-from ..utils.telegram_auth import TelegramAuthError
 
 
 class SessionManager:

--- a/src/telegram_download_chat/gui/tabs/settings_tab.py
+++ b/src/telegram_download_chat/gui/tabs/settings_tab.py
@@ -27,10 +27,10 @@ from telethon.errors import (
 )
 
 from ...core import TelegramChatDownloader
+from ...core.auth_utils import TelegramAuth, TelegramAuthError
 from ...paths import get_app_dir
 from ..auth import SessionManager
 from ..utils.config import ConfigManager
-from ..utils.telegram_auth import TelegramAuth, TelegramAuthError
 
 
 class CodeRequestWorker(QObject):

--- a/src/telegram_download_chat/gui/utils/__init__.py
+++ b/src/telegram_download_chat/gui/utils/__init__.py
@@ -6,12 +6,10 @@ This package contains utility modules used throughout the application.
 
 from .config import ConfigManager
 from .file_utils import ensure_dir_exists, format_file_size, get_file_size
-from .telegram_auth import TelegramAuth
 
 __all__ = [
     "ConfigManager",
     "ensure_dir_exists",
     "get_file_size",
     "format_file_size",
-    "TelegramAuth",
 ]


### PR DESCRIPTION
## Summary
- move `TelegramAuth` into `core` as `auth_utils.py`
- reuse `TelegramAuth` inside `AuthMixin.connect`
- update imports for new location
- adjust tests for new auth utils
- update project structure docs in AGENTS

## Testing
- `pre-commit run --files src/telegram_download_chat/core/auth_utils.py src/telegram_download_chat/gui/utils/__init__.py src/telegram_download_chat/gui/auth/session_manager.py src/telegram_download_chat/gui/tabs/settings_tab.py src/telegram_download_chat/core/auth.py src/telegram_download_chat/core/__init__.py AGENTS.md tests/test_telegram_download_chat.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688337e028f8832c97424d41dd0cbb44