### PR TITLE
Refactor settings tab

### DIFF
--- a/src/telegram_download_chat/gui/auth/session_manager.py
+++ b/src/telegram_download_chat/gui/auth/session_manager.py
@@ -115,6 +115,8 @@ class SessionManager:
 
                 await tab.telegram_auth.client.disconnect()
 
+                await tab._validate_session_async()
+
                 tab.auth_state_changed.emit(True)
 
             except TelegramAuthError as e:


### PR DESCRIPTION
## Summary
- delete unused worker and duplicate code callbacks
- run session validation immediately when required
- simplify code request thread logic
- validate session after login

## Testing
- `pre-commit run --files src/telegram_download_chat/gui/tabs/settings_tab.py src/telegram_download_chat/gui/auth/session_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688356cf5494832c804f6d9cdc679030