### PR TITLE
Add JSON results output option

### DIFF
--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -27,6 +27,7 @@ class CLIOptions:
     until: Optional[str] = None
     split: Optional[str] = None
     sort: str = "desc"
+    results_json: bool = False
 
 
 def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
@@ -106,6 +107,11 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
     )
     parser.add_argument(
         "-v", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument(
+        "--results-json",
+        action="store_true",
+        help="Output results summary as JSON to stdout",
     )
 
     args = parser.parse_args(argv)

--- a/src/telegram_download_chat/core/config.py
+++ b/src/telegram_download_chat/core/config.py
@@ -116,7 +116,7 @@ class ConfigMixin:
             file_handler.setFormatter(formatter)
             self.logger.addHandler(file_handler)
 
-        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setFormatter(formatter)
         self.logger.addHandler(console_handler)
 

--- a/tests/test_telegram_download_chat.py
+++ b/tests/test_telegram_download_chat.py
@@ -56,6 +56,12 @@ class TestCLIArgumentParsing:
             assert args.output is None
             assert args.sort == "desc"
 
+    def test_results_json_argument(self):
+        """Test parsing of --results-json option."""
+        with patch("sys.argv", ["script_name", "chat", "--results-json"]):
+            args = parse_args()
+            assert args.results_json is True
+
 
 class TestFilterMessagesBySubchat:
     """Tests for filter_messages_by_subchat function."""
@@ -376,6 +382,35 @@ class TestCLIExecution:
             assert call_args[0] == test_messages
             assert str(call_args[1]) == str(expected_output)
             assert call_args[2] == "desc"
+
+    @pytest.mark.asyncio
+    async def test_results_json_output(self, tmp_path):
+        """Test that --results-json outputs result summary to stdout."""
+        mock_downloader = AsyncMock()
+        mock_downloader.config = {"settings": {"save_path": str(tmp_path)}}
+        mock_downloader.logger = MagicMock()
+        mock_downloader.get_entity_name = AsyncMock(return_value="chat")
+        mock_downloader.get_entity_full_name = AsyncMock(return_value="Chat")
+        mock_entity = MagicMock(id=123)
+        mock_downloader.get_entity = AsyncMock(return_value=mock_entity)
+        mock_downloader.download_chat = AsyncMock(return_value=[{"id": 1}])
+        mock_downloader.save_messages = AsyncMock()
+
+        with patch("sys.argv", ["script_name", "chat", "--results-json"]), patch(
+            "telegram_download_chat.cli.TelegramChatDownloader",
+            return_value=mock_downloader,
+        ), patch(
+            "telegram_download_chat.paths.get_app_dir", return_value=tmp_path
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            result = await async_main()
+            output = mock_stdout.getvalue()
+
+        assert result == 0
+        data = json.loads(output)
+        assert "results" in data
+        assert data["results"][0]["chat_id"] == 123
 
     @pytest.mark.skip(
         reason="Skipping test_download_flow due to complexity of mocking."


### PR DESCRIPTION
## Summary
- add `--results-json` CLI option
- emit logs to `stderr`
- return JSON summary to stdout when `--results-json` is used
- test new argument and output behavior

## Testing
- `pre-commit run --files src/telegram_download_chat/cli/arguments.py src/telegram_download_chat/core/config.py src/telegram_download_chat/cli/commands.py src/telegram_download_chat/cli/__init__.py tests/test_telegram_download_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836d47470c832c859bc279bf6001e8