### PR TITLE
Add keywords search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A powerful command-line utility to download and analyze Telegram chat history in
 - Filter messages by date range and specific users
 - Extract sub-conversations from message threads
 - Output results summary in JSON format
+- Search messages for specific keywords
 - Cross-platform support (Windows, macOS, Linux)
 - Optional graphical user interface (GUI) for easier interaction
 - Core functionality resides under the `telegram_download_chat.core` package for easier maintenance.
@@ -199,6 +200,9 @@ telegram-download-chat --show-config
 
 # Output results summary as JSON
 telegram-download-chat username --results-json
+
+# Search chat for keywords
+telegram-download-chat username --keywords "@user,hello"
 ```
 
 ### Command Line Options
@@ -230,6 +234,7 @@ options:
   --sort {asc,desc}     Sort messages by date (default: desc)
   --show-config         Show config file location and exit
   --results-json        Output results summary as JSON to stdout
+  --keywords KEYWORDS  Comma-separated keywords to search in messages
   -v, --version         Show program's version number and exit
 ```
 

--- a/src/telegram_download_chat/cli/__init__.py
+++ b/src/telegram_download_chat/cli/__init__.py
@@ -26,7 +26,7 @@ from telegram_download_chat.paths import (
 
 from . import commands
 from .arguments import CLIOptions, parse_args
-from .commands import filter_messages_by_subchat
+from .commands import analyze_keywords, filter_messages_by_subchat
 
 _downloader_ctx: DownloaderContext | None = None
 
@@ -202,6 +202,7 @@ __all__ = [
     "CLIOptions",
     "commands",
     "filter_messages_by_subchat",
+    "analyze_keywords",
     "show_config",
     "convert_json_to_txt",
     "download_folder",

--- a/src/telegram_download_chat/cli/__init__.py
+++ b/src/telegram_download_chat/cli/__init__.py
@@ -154,7 +154,7 @@ async def async_main() -> int:
 
         if args.results_json:
             results = result if isinstance(result, list) else [result]
-            print(json.dumps({"results": results}, ensure_ascii=False))
+            print(json.dumps({"results": results}, ensure_ascii=False, indent=2))
 
         if isinstance(result, list):
             return 0 if all("error" not in r for r in result) else 1

--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -28,6 +28,7 @@ class CLIOptions:
     split: Optional[str] = None
     sort: str = "desc"
     results_json: bool = False
+    keywords: Optional[str] = None
 
 
 def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
@@ -112,6 +113,11 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
         "--results-json",
         action="store_true",
         help="Output results summary as JSON to stdout",
+    )
+    parser.add_argument(
+        "--keywords",
+        type=str,
+        help="Comma-separated keywords to search in messages",
     )
 
     args = parser.parse_args(argv)

--- a/src/telegram_download_chat/cli/commands.py
+++ b/src/telegram_download_chat/cli/commands.py
@@ -78,6 +78,54 @@ def filter_messages_by_subchat(
     return filtered
 
 
+def analyze_keywords(
+    keywords: List[str], messages: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Analyze messages for occurrences of keywords."""
+    results: List[Dict[str, Any]] = []
+    for kw in keywords:
+        kw = kw.strip()
+        if not kw:
+            continue
+        kw_lower = kw.lower()
+        matches = []
+        count = 0
+        for msg in messages:
+            text = msg.get("message") or msg.get("text") or ""
+            if isinstance(text, list):
+                text = "".join(
+                    part if isinstance(part, str) else part.get("text", "")
+                    for part in text
+                )
+            text_str = str(text)
+            if kw_lower in text_str.lower():
+                count += 1
+                sender = msg.get("from_id") or msg.get("sender_id") or {}
+                if isinstance(sender, dict):
+                    sender = (
+                        sender.get("user_id")
+                        or sender.get("channel_id")
+                        or sender.get("chat_id")
+                    )
+                username = f"@{sender}" if sender else None
+                peer = msg.get("peer_id") or msg.get("to_id") or {}
+                if isinstance(peer, dict):
+                    chat_id = (
+                        peer.get("channel_id")
+                        or peer.get("chat_id")
+                        or peer.get("user_id")
+                    )
+                else:
+                    chat_id = peer
+                msg_id = msg.get("id")
+                url = (
+                    f"https://t.me/c/{chat_id}/{msg_id}" if chat_id and msg_id else None
+                )
+                matches.append({"username": username, "text": text_str, "url": url})
+        results.append({"text": kw, "count": count, "messages": matches})
+    return results
+
+
 async def _run_with_status(
     task_coro: Any, logger: logging.Logger, message: str | None = None
 ):
@@ -175,6 +223,15 @@ async def process_chat_download(
     first_date = min(msg_dates).strftime("%Y-%m-%d") if msg_dates else None
     last_date = max(msg_dates).strftime("%Y-%m-%d") if msg_dates else None
 
+    keywords_data: List[Dict[str, Any]] = []
+    if args.keywords:
+        kw_list = [k.strip() for k in args.keywords.split(",") if k.strip()]
+        serializable = [
+            downloader.make_serializable(m.to_dict() if hasattr(m, "to_dict") else m)
+            for m in messages
+        ]
+        keywords_data = analyze_keywords(kw_list, serializable)
+
     if not messages:
         downloader.logger.warning("No messages to save")
         entity = await downloader.get_entity(chat_identifier)
@@ -197,6 +254,7 @@ async def process_chat_download(
             "to": None,
             "result_json": None,
             "result_txt": None,
+            "keywords": [],
         }
 
     try:
@@ -251,6 +309,7 @@ async def process_chat_download(
         "to": last_date,
         "result_json": output_file,
         "result_txt": str(Path(output_file).with_suffix(".txt")),
+        "keywords": keywords_data,
     }
 
 
@@ -296,6 +355,11 @@ async def convert(
     first_date = min(msg_dates).strftime("%Y-%m-%d") if msg_dates else None
     last_date = max(msg_dates).strftime("%Y-%m-%d") if msg_dates else None
 
+    keywords_data: List[Dict[str, Any]] = []
+    if args.keywords:
+        kw_list = [k.strip() for k in args.keywords.split(",") if k.strip()]
+        keywords_data = analyze_keywords(kw_list, messages)
+
     if args.split:
         split_messages = split_messages_by_date(messages, args.split)
         if not split_messages:
@@ -336,6 +400,7 @@ async def convert(
         "to": last_date,
         "result_json": str(json_path),
         "result_txt": str(txt_path),
+        "keywords": keywords_data,
     }
 
 
@@ -381,6 +446,7 @@ async def download(
 __all__ = [
     "split_messages_by_date",
     "filter_messages_by_subchat",
+    "analyze_keywords",
     "save_messages_with_status",
     "save_txt_with_status",
     "process_chat_download",


### PR DESCRIPTION
## Summary
- add `--keywords` CLI option
- analyze keywords in downloaded messages
- include keyword results in JSON output
- document keyword search usage
- test new argument and keyword analyzer

## Testing
- `pre-commit run --files src/telegram_download_chat/cli/arguments.py src/telegram_download_chat/cli/commands.py src/telegram_download_chat/cli/__init__.py README.md tests/test_telegram_download_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837f4c2068832caaad507f254372af