### PR TITLE
Change default sort order to ascending

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ options:
   --user USER           Filter messages by sender ID
   -c, --config CONFIG   Path to config file
   --debug               Enable debug logging
-  --sort {asc,desc}     Sort messages by date (default: desc)
+  --sort {asc,desc}     Sort messages by date (default: asc)
   --show-config         Show config file location and exit
   --results-json        Output results summary as JSON to stdout
   -v, --version         Show program's version number and exit

--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -26,7 +26,7 @@ class CLIOptions:
     last_days: Optional[int] = None
     until: Optional[str] = None
     split: Optional[str] = None
-    sort: str = "desc"
+    sort: str = "asc"
     results_json: bool = False
 
 
@@ -102,8 +102,8 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
     parser.add_argument(
         "--sort",
         choices=["asc", "desc"],
-        default="desc",
-        help="Sort messages by date (default: desc)",
+        default="asc",
+        help="Sort messages by date (default: asc)",
     )
     parser.add_argument(
         "-v", "--version", action="version", version=f"%(prog)s {__version__}"

--- a/src/telegram_download_chat/cli/commands.py
+++ b/src/telegram_download_chat/cli/commands.py
@@ -100,7 +100,7 @@ async def save_messages_with_status(
     downloader: TelegramChatDownloader,
     messages: List[Any],
     output_file: str,
-    sort_order: str = "desc",
+    sort_order: str = "asc",
 ) -> None:
     """Save messages to JSON displaying a status message if slow."""
     return await _run_with_status(
@@ -113,7 +113,7 @@ async def save_txt_with_status(
     downloader: TelegramChatDownloader,
     messages: List[Any],
     txt_file: Path,
-    sort_order: str = "desc",
+    sort_order: str = "asc",
 ) -> int:
     """Save messages to a text file with progress output."""
     return await _run_with_status(

--- a/src/telegram_download_chat/core/messages.py
+++ b/src/telegram_download_chat/core/messages.py
@@ -84,7 +84,7 @@ class MessagesMixin:
         return messages
 
     def prepare_messages_for_txt(
-        self, messages: List[Dict[str, Any]], sort_order: str = "desc"
+        self, messages: List[Dict[str, Any]], sort_order: str = "asc"
     ) -> List[Dict[str, Any]]:
         def parse_dt(msg: Dict[str, Any]) -> datetime:
             date_str = msg.get("date")
@@ -128,7 +128,7 @@ class MessagesMixin:
         return ordered_messages
 
     async def save_messages_as_txt(
-        self, messages: List[Dict[str, Any]], txt_path: Path, sort_order: str = "desc"
+        self, messages: List[Dict[str, Any]], txt_path: Path, sort_order: str = "asc"
     ) -> int:
         saved = 0
         txt_path.parent.mkdir(parents=True, exist_ok=True)
@@ -200,7 +200,7 @@ class MessagesMixin:
         messages,
         output_file: str,
         save_txt: bool = True,
-        sort_order: str = "desc",
+        sort_order: str = "asc",
     ) -> None:
         output_path = Path(output_file)
 

--- a/tests/test_telegram_download_chat.py
+++ b/tests/test_telegram_download_chat.py
@@ -54,7 +54,7 @@ class TestCLIArgumentParsing:
             assert args.chat == test_chat
             assert args.limit == 0  # Default value from cli.py
             assert args.output is None
-            assert args.sort == "desc"
+            assert args.sort == "asc"
 
     def test_results_json_argument(self):
         """Test parsing of --results-json option."""
@@ -381,7 +381,7 @@ class TestCLIExecution:
             call_args = mock_downloader.save_messages_as_txt.call_args[0]
             assert call_args[0] == test_messages
             assert str(call_args[1]) == str(expected_output)
-            assert call_args[2] == "desc"
+            assert call_args[2] == "asc"
 
     @pytest.mark.asyncio
     async def test_results_json_output(self, tmp_path):


### PR DESCRIPTION
## Summary
- default to ascending sort order in CLI
- update commands to use ascending order
- update core functions to sort ascending by default
- document default sort in README
- fix tests for new default

## Testing
- `pre-commit run --files README.md src/telegram_download_chat/cli/arguments.py src/telegram_download_chat/cli/commands.py src/telegram_download_chat/core/messages.py tests/test_telegram_download_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853c8432c0832c9981bb57e6b0eda7