### PR TITLE
Add bumpversion option to deploy script

### DIFF
--- a/.windsurf/workflows/release.md
+++ b/.windsurf/workflows/release.md
@@ -2,5 +2,4 @@
 description: release a new version
 ---
 
-- use bumpversion [patch|minor|major] for commit new version
-- run deploy.py
+- run `python deploy.py [patch|minor|major]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,13 @@ bumpversion minor
 bumpversion major
 ```
 
+Alternatively, you can run the deploy script with the desired level to bump the
+version and publish in one step:
+
+```bash
+python deploy.py patch  # or minor/major
+```
+
 This will:
 - Update version in all tracked files
 - Create a git commit with the version bump
@@ -93,7 +100,10 @@ This will:
 1. Ensure all changes for the release are merged to the main branch
 2. Make sure all tests are passing
 3. Update the CHANGELOG.md with the changes in this release
-4. Bump the version using bumpversion (see Version Management section above)
+4. Run the deploy script with the desired bump level, e.g.:
+   ```bash
+   python deploy.py patch
+   ```
 5. Push the version bump commit and tag:
    ```bash
    git push
@@ -129,10 +139,11 @@ git push --tags
 
 ### 4. Build and Publish
 
-Build and publish the package to PyPI using the deploy script:
+Build and publish the package to PyPI using the deploy script. Pass the bump
+level if you didn't bump it earlier:
 
 ```bash
-python deploy.py
+python deploy.py patch  # or minor/major
 ```
 
 This will:

--- a/README.md
+++ b/README.md
@@ -418,6 +418,12 @@ If you encounter any issues, please:
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+For releasing a new version to PyPI, run the deploy script with a bump level:
+
+```bash
+python deploy.py patch  # or minor/major
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/deploy.py
+++ b/deploy.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 import subprocess
@@ -50,7 +51,20 @@ def upload_package():
     subprocess.run(["python", "-m", "twine", "upload", "dist/*"], check=True)
 
 
-def main():
+def main() -> None:
+    """Run deployment steps with optional version bump."""
+    parser = argparse.ArgumentParser(description="Build and upload the package")
+    parser.add_argument(
+        "bump",
+        nargs="?",
+        choices=["patch", "minor", "major"],
+        help="Run bumpversion before deployment",
+    )
+    args = parser.parse_args()
+
+    if args.bump:
+        subprocess.run(["bumpversion", args.bump], check=True)
+
     # Run tests first
     if not run_tests():
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add argparse with patch/minor/major level to deploy.py
- update developer docs to use the new bump option
- document deploy usage in README
- refresh release workflow note

## Testing
- `pre-commit run --files deploy.py CONTRIBUTING.md README.md .windsurf/workflows/release.md`
- `PYTHONPATH=src pytest -p pytest_asyncio -q`

------
https://chatgpt.com/codex/tasks/task_e_68853d2e6bd4832c9d503ccf44bb6468