### PR TITLE
Add multiple chat support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Exciting New Features
 - feat: download any chat with --limit and --until
+- feat: support downloading multiple chats at once
 - feat: download chat by any type chat identifier, add --subchat-name
 - feat: --user filter, convert archive to messages
 - feat: --split

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ telegram-download-chat https://t.me/+invite_code
 
 # Download chat by phone number (must be in your contacts)
 telegram-download-chat +1234567890
+
+# Download multiple chats at once
+telegram-download-chat chat1,chat2,chat3
 ```
 
 ### Advanced Usage

--- a/src/telegram_download_chat/cli/__init__.py
+++ b/src/telegram_download_chat/cli/__init__.py
@@ -9,6 +9,7 @@ import logging
 import signal
 import sys
 import tempfile
+from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -126,7 +127,8 @@ async def async_main() -> int:
                 "%Y-%m-%d"
             )
 
-        if not args.chat:
+        chats = args.chats or ([args.chat] if args.chat else [])
+        if not chats:
             downloader.logger.error("Chat identifier is required")
             return 1
 
@@ -141,24 +143,43 @@ async def async_main() -> int:
         )
         downloads_dir.mkdir(parents=True, exist_ok=True)
 
-        if args.subchat and not args.output and not args.chat.endswith(".json"):
-            downloader.logger.error("--subchat requires an existing JSON file as input")
-            return 1
+        results = []
+        for chat_id in chats:
+            chat_args = replace(args, chat=chat_id, chats=[chat_id])
 
-        if args.chat.endswith(".json"):
-            result = await convert_json_to_txt(ctx, downloader, args, downloads_dir)
-        elif args.chat.startswith("folder:"):
-            result = await download_folder(ctx, downloader, args, downloads_dir)
-        else:
-            result = await download_chat(ctx, downloader, args, downloads_dir)
+            if (
+                chat_args.subchat
+                and not chat_args.output
+                and not chat_id.endswith(".json")
+            ):
+                downloader.logger.error(
+                    "--subchat requires an existing JSON file as input"
+                )
+                return 1
+
+            if chat_id.endswith(".json"):
+                result = await convert_json_to_txt(
+                    ctx, downloader, chat_args, downloads_dir
+                )
+            elif chat_id.startswith("folder:"):
+                result = await download_folder(
+                    ctx, downloader, chat_args, downloads_dir
+                )
+            else:
+                result = await download_chat(ctx, downloader, chat_args, downloads_dir)
+
+            results.append(result)
+
+        flat_results = [i for r in results for i in (r if isinstance(r, list) else [r])]
 
         if args.results_json:
-            results = result if isinstance(result, list) else [result]
-            print(json.dumps({"results": results}, ensure_ascii=False))
+            print(json.dumps({"results": flat_results}, ensure_ascii=False))
 
-        if isinstance(result, list):
-            return 0 if all("error" not in r for r in result) else 1
-        return 0 if "error" not in result else 1
+        return (
+            0
+            if all(isinstance(r, dict) and "error" not in r for r in flat_results)
+            else 1
+        )
 
     except Exception as e:  # pragma: no cover - just logging
         downloader.logger.exception(f"An error occurred: {e}")

--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import List, Optional
 
 from telegram_download_chat import __version__
 
@@ -14,6 +14,7 @@ class CLIOptions:
     """Parsed command line options."""
 
     chat: Optional[str] = None
+    chats: List[str] = field(default_factory=list)
     output: Optional[str] = None
     limit: int = 0
     config: Optional[str] = None
@@ -115,7 +116,15 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
     )
 
     args = parser.parse_args(argv)
-    return CLIOptions(**vars(args))
+
+    chat_list: List[str] = []
+    if args.chat:
+        chat_list = [c.strip() for c in args.chat.split(",") if c.strip()]
+        args.chat = chat_list[0]
+
+    args_dict = vars(args)
+    args_dict["chats"] = chat_list
+    return CLIOptions(**args_dict)
 
 
 __all__ = ["CLIOptions", "parse_args"]

--- a/tests/test_telegram_download_chat.py
+++ b/tests/test_telegram_download_chat.py
@@ -52,15 +52,24 @@ class TestCLIArgumentParsing:
         with patch("sys.argv", ["script_name", test_chat]):
             args = parse_args()
             assert args.chat == test_chat
+            assert args.chats == [test_chat]
             assert args.limit == 0  # Default value from cli.py
             assert args.output is None
             assert args.sort == "desc"
+
+    def test_multiple_chats_argument(self):
+        """Test parsing multiple chats separated by commas."""
+        with patch("sys.argv", ["script_name", "chat1,chat2"]):
+            args = parse_args()
+            assert args.chat == "chat1"
+            assert args.chats == ["chat1", "chat2"]
 
     def test_results_json_argument(self):
         """Test parsing of --results-json option."""
         with patch("sys.argv", ["script_name", "chat", "--results-json"]):
             args = parse_args()
             assert args.results_json is True
+            assert args.chats == ["chat"]
 
 
 class TestFilterMessagesBySubchat:
@@ -166,6 +175,7 @@ class TestFilterMessagesBySubchat:
         with patch("sys.argv", test_args):
             args = parse_args()
             assert args.chat == "test_chat"
+            assert args.chats == ["test_chat"]
             assert args.limit == 100
             assert args.output == "output.json"
             assert args.config == "custom_config.yml"
@@ -216,6 +226,7 @@ class TestFilterMessagesBySubchat:
         with patch("sys.argv", ["script_name", "chat_history.json"]):
             args = parse_args()
             assert args.chat == "chat_history.json"
+            assert args.chats == ["chat_history.json"]
             # Should not require --output for JSON input
             assert args.output is None
             # subchat_name should be None by default
@@ -236,6 +247,7 @@ class TestFilterMessagesBySubchat:
         ):
             args = parse_args()
             assert args.chat == "chat_history.json"
+            assert args.chats == ["chat_history.json"]
             assert args.subchat == "123"
             assert args.subchat_name == "custom_subchat"
 
@@ -420,6 +432,43 @@ class TestCLIExecution:
         assert result_info["messages"] == 1
         assert result_info["from"] == "2025-07-10"
         assert result_info["to"] == "2025-07-10"
+
+    @pytest.mark.asyncio
+    async def test_multiple_chats_download(self, tmp_path):
+        """Test downloading multiple chats sequentially."""
+        mock_downloader = AsyncMock()
+        mock_downloader.config = {"settings": {"save_path": str(tmp_path)}}
+        mock_downloader.logger = MagicMock()
+        mock_downloader.get_entity_name = AsyncMock(return_value="chat")
+        mock_downloader.get_entity_full_name = AsyncMock(return_value="Chat")
+        mock_downloader.get_entity = AsyncMock(return_value=MagicMock(id=123))
+        from datetime import datetime
+
+        msg = MagicMock()
+        msg.id = 1
+        msg.date = datetime(2025, 7, 10, 12, 0, 0)
+        mock_downloader.download_chat = AsyncMock(return_value=[msg])
+        mock_downloader.save_messages = AsyncMock()
+
+        with patch(
+            "sys.argv",
+            ["script_name", "chat1,chat2", "--results-json"],
+        ), patch(
+            "telegram_download_chat.cli.TelegramChatDownloader",
+            return_value=mock_downloader,
+        ), patch(
+            "telegram_download_chat.paths.get_app_dir", return_value=tmp_path
+        ), patch(
+            "sys.stdout", new_callable=StringIO
+        ) as mock_stdout:
+            result = await async_main()
+            output = mock_stdout.getvalue()
+
+        assert result == 0
+        data = json.loads(output)
+        assert "results" in data
+        assert len(data["results"]) == 2
+        assert mock_downloader.download_chat.call_count == 2
 
     @pytest.mark.skip(
         reason="Skipping test_download_flow due to complexity of mocking."


### PR DESCRIPTION
## Summary
- allow parsing comma-separated chat identifiers
- iterate over each chat in CLI async entry point
- document new feature and list in changelog
- add regression tests for parsing and CLI logic

## Testing
- `pre-commit run --files src/telegram_download_chat/cli/__init__.py src/telegram_download_chat/cli/arguments.py tests/test_telegram_download_chat.py README.md CHANGELOG.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853e254484832cbf943fa0212b29b3