### PR TITLE
Add streamlit web interface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ src/telegram_download_chat/
 │       ├── file_utils.py     # File operations
 │
 └── gui_app_.py              # Old GUI implementation (renamed)
+├── web/                     # Streamlit web interface
+│   ├── __init__.py
+│   └── main.py              # Streamlit entry point
 ├── cli/                     # Command line interface package
 │   ├── __init__.py          # CLI entry point
 │   ├── arguments.py         # Argument parsing helpers

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ The GUI provides an easy-to-use interface with the following features:
 - File preview functionality
 - Browse and open downloaded files
 
+### Web Version (Optional)
+
+A simple web interface built with Streamlit is also available.
+
+1. Install with web dependencies:
+   ```bash
+   pip install "telegram-download-chat[web]"
+   ```
+
+2. Launch the web UI:
+   ```bash
+   telegram-download-chat web
+   ```
+
 ### Install from PyPI (recommended)
 
 ```bash
@@ -358,6 +372,16 @@ This feature is particularly useful for:
 | Configuration | Visual forms | Manual config editing |
 | Batch operations | One chat at a time | Scriptable |
 | Automation | Interactive only | Fully scriptable |
+
+## Web Interface (Streamlit)
+
+You can also run a simple Streamlit-based interface:
+
+```bash
+telegram-download-chat web
+```
+
+This provides a minimal web UI for downloading chats from your browser.
 
 ## Output Formats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 gui = [
     "PySide6>=6.5.0"
 ]
+web = [
+    "streamlit>=1.32.0"
+]
 dev = [
     "pytest>=6.0",
     "pytest-asyncio>=0.21",
@@ -59,6 +62,7 @@ __version_tuple__ = version_tuple = {version_tuple}
 
 [project.scripts]
 telegram-download-chat = "telegram_download_chat.cli:main"
+telegram-download-chat-web = "telegram_download_chat.web.main:main"
 
 [project.urls]
 Homepage = "https://github.com/popstas/telegram-download-chat"

--- a/src/telegram_download_chat/cli/__init__.py
+++ b/src/telegram_download_chat/cli/__init__.py
@@ -19,6 +19,11 @@ try:  # GUI is optional
     from telegram_download_chat.gui.main import main as gui_main
 except ImportError:  # pragma: no cover - GUI optional
     gui_main = None
+
+try:  # Web UI is optional
+    from telegram_download_chat.web.main import main as web_main
+except ImportError:  # pragma: no cover - Web optional
+    web_main = None
 from telegram_download_chat.paths import (
     get_default_config_path,
     get_downloads_dir,
@@ -190,6 +195,16 @@ async def async_main() -> int:
 
 def main() -> int:
     """Synchronous entry point for the CLI."""
+    if len(sys.argv) >= 2 and sys.argv[1] == "web":
+        if web_main is not None:
+            web_main()
+            return 0
+        print(
+            "Web UI dependencies not installed. Please install with: pip install 'telegram-download-chat[web]'",
+            file=sys.stderr,
+        )
+        return 1
+
     if (len(sys.argv) >= 2 and sys.argv[1] == "gui") or len(sys.argv) == 1:
         if gui_main is not None:
             try:

--- a/src/telegram_download_chat/web/main.py
+++ b/src/telegram_download_chat/web/main.py
@@ -1,0 +1,44 @@
+import asyncio
+from pathlib import Path
+
+import streamlit as st
+
+from telegram_download_chat.cli.arguments import CLIOptions
+from telegram_download_chat.cli.commands import download
+from telegram_download_chat.core import DownloaderContext, TelegramChatDownloader
+from telegram_download_chat.paths import get_downloads_dir
+
+
+def run_download(chat: str, limit: int, until: str | None) -> dict:
+    downloader = TelegramChatDownloader()
+
+    async def _run() -> dict:
+        ctx = DownloaderContext(downloader)
+        async with ctx:
+            downloads_dir = Path(
+                downloader.config.get("settings", {}).get(
+                    "save_path", get_downloads_dir()
+                )
+            )
+            downloads_dir.mkdir(parents=True, exist_ok=True)
+            opts = CLIOptions(chat=chat, limit=limit, until=until)
+            return await download(downloader, opts, downloads_dir)
+
+    return asyncio.run(_run())
+
+
+def main() -> None:
+    """Launch the Streamlit web interface."""
+    st.title("Telegram Download Chat")
+
+    chat = st.text_input("Chat identifier")
+    limit = st.number_input("Message limit", value=0, step=100, min_value=0)
+    until = st.text_input("Until date (YYYY-MM-DD)", "")
+
+    if st.button("Download") and chat:
+        result = run_download(chat, int(limit), until or None)
+        st.json(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add optional Streamlit web UI and hook into CLI
- expose `telegram-download-chat-web` entry point
- document new web interface usage
- update project structure docs in AGENTS

## Testing
- `pre-commit run --files README.md AGENTS.md pyproject.toml src/telegram_download_chat/web/main.py src/telegram_download_chat/cli/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688547950fa8832cb837891863952277