### PR TITLE
Add Gradio web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A powerful command-line utility to download and analyze Telegram chat history in
 - Search messages for specific keywords
 - Cross-platform support (Windows, macOS, Linux)
 - Optional graphical user interface (GUI) for easier interaction
+- Optional web interface (Gradio) for browser-based usage
 - Core functionality resides under the `telegram_download_chat.core` package for easier maintenance.
 
 ## Project Structure
@@ -94,6 +95,17 @@ The GUI provides an easy-to-use interface with the following features:
 - Real-time log viewing
 - File preview functionality
 - Browse and open downloaded files
+### Web Interface (Optional)
+
+To run a simple web interface using Gradio:
+1. Install with web dependencies:
+```bash
+pip install "telegram-download-chat[web]"
+```
+2. Launch the web app:
+```bash
+telegram-download-chat-web
+```
 
 ### Install from PyPI (recommended)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dependencies = [
 gui = [
     "PySide6>=6.5.0"
 ]
+web = [
+    "gradio>=5.0"
+]
+
 dev = [
     "pytest>=6.0",
     "pytest-asyncio>=0.21",
@@ -59,6 +63,7 @@ __version_tuple__ = version_tuple = {version_tuple}
 
 [project.scripts]
 telegram-download-chat = "telegram_download_chat.cli:main"
+telegram-download-chat-web = "telegram_download_chat.web.main:main"
 
 [project.urls]
 Homepage = "https://github.com/popstas/telegram-download-chat"

--- a/src/telegram_download_chat/web/main.py
+++ b/src/telegram_download_chat/web/main.py
@@ -1,0 +1,44 @@
+import asyncio
+
+import gradio as gr
+
+from telegram_download_chat.cli.arguments import CLIOptions
+from telegram_download_chat.cli.commands import process_chat_download
+from telegram_download_chat.core import DownloaderContext, TelegramChatDownloader
+from telegram_download_chat.paths import get_downloads_dir
+
+
+async def download_chat(chat_id: str, limit: int = 100) -> str:
+    """Download a chat and return path to the saved JSON file."""
+    downloader = TelegramChatDownloader()
+    ctx = DownloaderContext(downloader)
+    args = CLIOptions(chat=chat_id, chats=[chat_id], limit=limit)
+    downloads_dir = get_downloads_dir()
+    async with ctx:
+        result = await process_chat_download(downloader, chat_id, args, downloads_dir)
+    if error := result.get("error"):
+        return f"Error: {error}"
+    return f"Saved to {result.get('result_json')}"
+
+
+def gradio_download(chat_id: str, limit: int = 100) -> str:
+    return asyncio.run(download_chat(chat_id, int(limit)))
+
+
+def main() -> None:
+    """Launch the Gradio web interface."""
+    iface = gr.Interface(
+        fn=gradio_download,
+        inputs=[
+            gr.Textbox(label="Chat ID", placeholder="@username or chat id"),
+            gr.Number(label="Limit", value=100),
+        ],
+        outputs="text",
+        title="Telegram Chat Downloader",
+        description="Download Telegram chats through a simple web interface.",
+    )
+    iface.launch()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add minimal web interface using Gradio
- add optional `web` extras and CLI entry point
- document web usage in README

## Testing
- `pre-commit run --files README.md pyproject.toml src/telegram_download_chat/web/main.py src/telegram_download_chat/web/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885479dd468832c95c7036026d23813