### PR TITLE
Add NiceGUI web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ The GUI provides an easy-to-use interface with the following features:
 - File preview functionality
 - Browse and open downloaded files
 
+### Web Interface (Optional)
+
+A minimal web interface built with [NiceGUI](https://nicegui.io) is also available.
+
+1. Install with web dependencies:
+   ```bash
+   pip install "telegram-download-chat[web]"
+   ```
+
+2. Launch the web UI:
+   ```bash
+   telegram-download-chat web
+   ```
+
 ### Install from PyPI (recommended)
 
 ```bash
@@ -358,6 +372,17 @@ This feature is particularly useful for:
 | Configuration | Visual forms | Manual config editing |
 | Batch operations | One chat at a time | Scriptable |
 | Automation | Interactive only | Fully scriptable |
+
+## Web Interface (NiceGUI)
+
+The project also includes a lightweight web interface built with NiceGUI.
+Run it with:
+
+```bash
+telegram-download-chat web
+```
+
+Use your browser to enter the chat identifier and start a download.
 
 ## Output Formats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
 gui = [
     "PySide6>=6.5.0"
 ]
+web = [
+    "nicegui>=2.0.0"
+]
 dev = [
     "pytest>=6.0",
     "pytest-asyncio>=0.21",

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,14 @@ setup(
         "PyYAML>=6.0.0",
     ],
     extras_require={
+        "gui": ["PySide6>=6.5.0"],
+        "web": ["nicegui>=2.0.0"],
         "dev": [
             "pytest>=6.0",
             "black>=22.0",
             "isort>=5.0",
             "mypy>=0.900",
-        ]
+        ],
     },
     entry_points={
         "console_scripts": [

--- a/src/telegram_download_chat/cli/__init__.py
+++ b/src/telegram_download_chat/cli/__init__.py
@@ -19,6 +19,11 @@ try:  # GUI is optional
     from telegram_download_chat.gui.main import main as gui_main
 except ImportError:  # pragma: no cover - GUI optional
     gui_main = None
+
+try:  # Web UI is optional
+    from telegram_download_chat.web.main import main as web_main
+except ImportError:  # pragma: no cover - web optional
+    web_main = None
 from telegram_download_chat.paths import (
     get_default_config_path,
     get_downloads_dir,
@@ -190,7 +195,39 @@ async def async_main() -> int:
 
 def main() -> int:
     """Synchronous entry point for the CLI."""
-    if (len(sys.argv) >= 2 and sys.argv[1] == "gui") or len(sys.argv) == 1:
+    if len(sys.argv) >= 2 and sys.argv[1] in {"gui", "web"}:
+        mode = sys.argv[1]
+        if mode == "gui":
+            if gui_main is not None:
+                try:
+                    gui_main()
+                    return 0
+                except Exception as e:  # pragma: no cover - GUI optional
+                    print(f"Error starting GUI: {e}", file=sys.stderr)
+                    print(e, file=sys.stderr)
+                    return 1
+            else:
+                print(
+                    "GUI dependencies not installed. Please install with: pip install 'telegram-download-chat[gui]'",
+                    file=sys.stderr,
+                )
+                return 1
+        else:  # web
+            if web_main is not None:
+                try:
+                    web_main()
+                    return 0
+                except Exception as e:  # pragma: no cover - web optional
+                    print(f"Error starting web UI: {e}", file=sys.stderr)
+                    print(e, file=sys.stderr)
+                    return 1
+            else:
+                print(
+                    "Web UI dependencies not installed. Please install with: pip install 'telegram-download-chat[web]'",
+                    file=sys.stderr,
+                )
+                return 1
+    elif len(sys.argv) == 1:
         if gui_main is not None:
             try:
                 gui_main()

--- a/src/telegram_download_chat/web/__init__.py
+++ b/src/telegram_download_chat/web/__init__.py
@@ -1,0 +1,5 @@
+"""Web interface powered by NiceGUI."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/src/telegram_download_chat/web/main.py
+++ b/src/telegram_download_chat/web/main.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from nicegui import ui
+
+from telegram_download_chat.cli import commands
+from telegram_download_chat.cli.arguments import CLIOptions
+from telegram_download_chat.core import DownloaderContext, TelegramChatDownloader
+from telegram_download_chat.paths import get_downloads_dir
+
+chat_input = ui.input("Chat identifier")
+limit_input = ui.input("Message limit", value="0")
+
+
+async def start_download() -> None:
+    chat = chat_input.value.strip()
+    try:
+        limit = int(limit_input.value or 0)
+    except ValueError:
+        limit = 0
+
+    downloader = TelegramChatDownloader()
+    ctx = DownloaderContext(downloader)
+    args = CLIOptions(chat=chat, chats=[chat], limit=limit)
+    downloads_dir = Path(
+        downloader.config.get("settings", {}).get("save_path", get_downloads_dir())
+    )
+    async with ctx:
+        result = await commands.download(downloader, args, downloads_dir)
+    ui.notify(f"Downloaded {result.get('messages', 0)} messages")
+
+
+def main() -> None:
+    ui.button("Download", on_click=lambda: asyncio.create_task(start_download()))
+    ui.run(title="Telegram Download Chat Web")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add NiceGUI-based web interface and expose via CLI
- add `web` optional dependency for NiceGUI
- document web interface in README

## Testing
- `pre-commit run --files README.md pyproject.toml setup.py src/telegram_download_chat/cli/__init__.py src/telegram_download_chat/web/__init__.py src/telegram_download_chat/web/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688548669ad4832c831b0a916ad96c5e