### PR TITLE
Rename web app entry and simplify UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ src/telegram_download_chat/
 │       ├── file_utils.py     # File operations
 ├── web/                      # Streamlit web interface
 │   ├── __init__.py           # Entry point to launch Streamlit
-│   └── streamlit_app.py      # Streamlit application code
+│   └── main.py               # Streamlit application code
 │
 └── gui_app_.py              # Old GUI implementation (renamed)
 ├── cli/                     # Command line interface package

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The GUI provides an easy-to-use interface with the following features:
 ### Streamlit Web Interface (Optional)
 
 A lightweight web interface built with Streamlit is also available.
-It mirrors all command line options and shows progress while
-downloading.
+It provides a subset of common command line options and shows progress
+while downloading.
 
 1. Install with web dependencies:
    ```bash

--- a/src/telegram_download_chat/web/__init__.py
+++ b/src/telegram_download_chat/web/__init__.py
@@ -8,7 +8,7 @@ import streamlit.web.cli as stcli
 
 def main() -> int:
     """Run the Streamlit application."""
-    script_path = os.path.join(os.path.dirname(__file__), "streamlit_app.py")
+    script_path = os.path.join(os.path.dirname(__file__), "main.py")
     sys.argv = ["streamlit", "run", script_path]
     return stcli.main()
 

--- a/src/telegram_download_chat/web/main.py
+++ b/src/telegram_download_chat/web/main.py
@@ -102,25 +102,18 @@ def build_options() -> CLIOptions | None:
         limit = int(
             st.number_input("Message limit (0 = no limit)", min_value=0, value=0)
         )
-        config = st.text_input("Config path")
-        debug = st.checkbox("Debug logging")
-        show_cfg = st.checkbox("Show config and exit")
-        subchat = st.text_input("Subchat ID/URL")
-        subchat_name = st.text_input("Subchat name")
-        user = st.text_input("Filter by sender")
         from_date = st.text_input("Base date for --last-days (YYYY-MM-DD)")
         last_days = st.number_input("Last days", min_value=0, value=0)
         until = st.text_input("Until date (YYYY-MM-DD)")
         split = st.selectbox("Split output", ["", "month", "year"]) or None
         sort = st.selectbox("Sort order", ["asc", "desc"])
-        results_json = st.checkbox("Results JSON")
         keywords = st.text_input("Keywords (comma separated)")
         submitted = st.form_submit_button("Download")
 
     if not submitted:
         return None
 
-    if not chat and not show_cfg:
+    if not chat:
         st.error("Chat ID is required")
         return None
 
@@ -129,18 +122,18 @@ def build_options() -> CLIOptions | None:
         chats=[chat] if chat else [],
         output=output or None,
         limit=limit,
-        config=config or None,
-        debug=debug,
-        show_config=show_cfg,
-        subchat=subchat or None,
-        subchat_name=subchat_name or None,
-        user=user or None,
+        config=None,
+        debug=False,
+        show_config=False,
+        subchat=None,
+        subchat_name=None,
+        user=None,
         from_date=from_date or None,
         last_days=int(last_days) if last_days else None,
         until=until or None,
         split=split,
         sort=sort,
-        results_json=results_json,
+        results_json=False,
         keywords=keywords or None,
     )
 


### PR DESCRIPTION
## Summary
- rename `streamlit_app.py` to `main.py` and update entry path
- drop several advanced options from the Streamlit form
- update docs and AGENTS structure to reference the new file

## Testing
- `pre-commit run --files AGENTS.md README.md src/telegram_download_chat/web/__init__.py src/telegram_download_chat/web/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68861ed5a128832ca2874a9d720fa0e9