### PR TITLE
Fix login verification check

### DIFF
--- a/src/telegram_download_chat/gui/auth/session_manager.py
+++ b/src/telegram_download_chat/gui/auth/session_manager.py
@@ -44,7 +44,13 @@ class SessionManager:
 
             logging.info(f"Attempting login with phone: {phone}")
 
-            if not hasattr(tab, "downloader") or not tab.downloader:
+            # If the user hasn't requested a verification code yet, the
+            # `phone_code_hash` attribute will be empty. Earlier versions
+            # relied on the downloader instance being present, but the
+            # downloader is now closed right after sending the code to avoid
+            # database locks.  We only need the phone_code_hash for signing in,
+            # so check that instead of the downloader instance.
+            if not getattr(tab, "phone_code_hash", None):
                 error_msg = "Please request a verification code first."
                 logging.error(error_msg)
                 QMessageBox.critical(tab, "Error", error_msg)


### PR DESCRIPTION
## Summary
- fix login requirement check when downloader closes after code request

## Testing
- `pre-commit run --files src/telegram_download_chat/gui/auth/session_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886784e1b74832c8009899ccbeb8479