### PR TITLE
Add since-id resume option

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ telegram-download-chat username --keywords "@user,hello"
 
 # Use predefined preset
 telegram-download-chat username --preset short
+
+# Resume download starting after a specific message ID
+telegram-download-chat username --since-id 5000
 ```
 
 ### Command Line Options
@@ -255,6 +258,7 @@ options:
   -h, --help            show this help message and exit
   -o, --output OUTPUT    Output file path (default: chat_<chat_id>.json)
   -l, --limit LIMIT     Maximum number of messages to download (default: 0 - no limit)
+  --since-id SINCE_ID  Start downloading after this message ID
   --from DATE           Base date for --last-days (format: YYYY-MM-DD)
   --last-days DAYS      Number of days back from --from (or today) to download
   --until DATE          Only download messages until this date (format: YYYY-MM-DD)
@@ -298,6 +302,7 @@ The tool will process the archive and generate both JSON and TXT files with the 
 
 ### Resuming Interrupted Downloads
 If the download is interrupted, you can simply run the same command again to resume from where it left off. The tool automatically saves progress to a temporary file.
+You can also resume later using `--since-id` with the last downloaded message ID or let the tool read it from the existing JSON file.
 
 ### User Mapping
 Display names for users and bots are collected automatically. You can override them in the `users_map` section:

--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -17,6 +17,7 @@ class CLIOptions:
     chats: List[str] = field(default_factory=list)
     output: Optional[str] = None
     limit: int = 0
+    since_id: Optional[int] = None
     config: Optional[str] = None
     debug: bool = False
     show_config: bool = False
@@ -54,6 +55,11 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
         type=int,
         default=0,
         help="Maximum number of messages to download (default: 0 - no limit)",
+    )
+    parser.add_argument(
+        "--since-id",
+        type=int,
+        help="Start downloading after the specified message ID",
     )
     parser.add_argument(
         "-c",


### PR DESCRIPTION
## Summary
- add `--since-id` argument to CLI
- read last message id from existing JSON when `--since-id` not supplied
- allow DownloadMixin.download_chat to skip previously fetched messages
- document resume option in README
- test resuming downloads from a specific ID

## Testing
- `pre-commit run --files src/telegram_download_chat/cli/arguments.py src/telegram_download_chat/cli/commands.py src/telegram_download_chat/core/download.py README.md tests/test_telegram_download_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889440d0d64832cb8a109f729b0a216