### PR TITLE
Add JSONL output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A powerful command-line utility to download and analyze Telegram chat history in
 - Download chats folder
 - Save messages in JSON format with full message metadata
 - Generate human and LLM readable TXT exports with user-friendly display names
+- Optionally save plain message texts in JSONL format with `--jsonl`
 - Filter messages by date range and specific users
 - Extract sub-conversations from message threads
 - Output results summary in JSON format
@@ -434,6 +435,9 @@ A human-readable version of the chat with:
 - Display names from your `users_map`
 - Message content with basic formatting
 - Reply indicators
+
+### JSONL Output (`[chat_name].jsonl`)
+Plain message texts only, one per line encoded as JSON. Enable with `--jsonl`.
 
 ### Example Output Structure
 

--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -30,6 +30,7 @@ class CLIOptions:
     split: Optional[str] = None
     sort: str = "asc"
     results_json: bool = False
+    jsonl: bool = False
     keywords: Optional[str] = None
     preset: Optional[str] = None
 
@@ -121,6 +122,11 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
         "--results-json",
         action="store_true",
         help="Output results summary as JSON to stdout",
+    )
+    parser.add_argument(
+        "--jsonl",
+        action="store_true",
+        help="Save only message texts to JSONL alongside JSON output",
     )
     parser.add_argument(
         "--keywords",


### PR DESCRIPTION
## Summary
- add `--jsonl` CLI option
- support saving plain message texts to `.jsonl`
- extend README with jsonl details
- test `--jsonl` parsing and saving behavior

## Testing
- `pre-commit run --files README.md src/telegram_download_chat/cli/arguments.py src/telegram_download_chat/cli/commands.py src/telegram_download_chat/core/messages.py tests/test_telegram_download_chat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a68f608a0832c9192c2c90bee01b6