### PR TITLE
Implement downloading media with `--media` flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ src/telegram_download_chat/
 │   ├── config.py             # Configuration helpers
 │   ├── download.py           # Chat downloading logic
 │   ├── entities.py           # Entity utilities
+│   ├── media.py              # Media download utilities
 │   ├── messages.py           # Message formatting utilities
 │   └── presets.py            # Preset management helpers
 ├── gui/                      # Main GUI package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Telegram Download Chat is a Python CLI utility that downloads and analyzes Teleg
 
 ### Key Components
 
-- **Core Engine** (`core/` package): Contains `TelegramChatDownloader` plus helper modules (`auth`, `config`, `download`, `entities`, `messages`, `context`) built on Telethon
+- **Core Engine** (`core/` package): Contains `TelegramChatDownloader` plus helper modules (`auth`, `config`, `download`, `entities`, `media`, `messages`, `context`) built on Telethon
 - **CLI Interface** (`cli.py`): Command-line interface with argument parsing and async message processing
 - **GUI Interface** (`gui_app.py`): PySide6-based graphical interface with threading for async operations
 - **Configuration** (`paths.py`): Handles config file management and application directories
@@ -108,6 +108,7 @@ python main.py  # Launches GUI by default
 - `--split`: Split output by month/year
 - `--user`: Filter by specific sender
 - `--until`: Date-based filtering
+- `--media`: Download media attachments (photos, videos, documents, etc.)
 
 ### PyInstaller Integration
 - Custom hooks in `_pyinstaller/` for bundling

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A powerful command-line utility to download and analyze Telegram chat history in
 - Download chats folder
 - Save messages in JSON format with full message metadata
 - Generate human and LLM readable TXT exports with user-friendly display names
+- **Download media attachments** (photos, videos, documents, audio, etc.) with `--media` flag
 - Filter messages by date range and specific users
 - Extract sub-conversations from message threads
 - Output results summary in JSON format
@@ -238,6 +239,9 @@ telegram-download-chat username --preset short
 
 # Resume download starting after a specific message ID
 telegram-download-chat username --since-id 5000
+
+# Download messages with media attachments (photos, videos, documents, etc.)
+telegram-download-chat username --media
 ```
 
 ### Command Line Options
@@ -272,6 +276,7 @@ options:
   --results-json        Output results summary as JSON to stdout
   --keywords KEYWORDS  Comma-separated keywords to search in messages
   --preset PRESET     Use preset from config
+  --media               Download media attachments to a separate folder
   -v, --version         Show program's version number and exit
 ```
 
@@ -435,6 +440,29 @@ A human-readable version of the chat with:
 - Display names from your `users_map`
 - Message content with basic formatting
 - Reply indicators
+
+### Media Attachments (`[chat_name]_attachments/`)
+When using the `--media` flag, media files are downloaded to a separate folder with the following structure:
+
+```
+[chat_name]_attachments/
+├── 12345/                    # Message ID
+│   └── 123456789000.jpg      # Downloaded media file
+├── 12346/
+│   └── 2937458923.pdf
+└── 12347/
+    └── 9832749823498723.mp4
+```
+
+Each message's media is stored in a directory named after the message ID.
+
+Supported media types:
+- **Photos**: Downloaded as JPG files
+- **Videos**: Including video messages and round videos
+- **Documents**: PDFs, archives, office files, etc.
+- **Audio**: Music files and audio messages
+- **Voice messages**: Voice recordings
+- **Stickers**: Including animated stickers
 
 ### Example Output Structure
 

--- a/src/telegram_download_chat/cli/arguments.py
+++ b/src/telegram_download_chat/cli/arguments.py
@@ -32,6 +32,7 @@ class CLIOptions:
     results_json: bool = False
     keywords: Optional[str] = None
     preset: Optional[str] = None
+    media: bool = False
 
 
 def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
@@ -131,6 +132,11 @@ def parse_args(argv: Optional[list[str]] = None) -> CLIOptions:
         "--preset",
         type=str,
         help="Name of preset from config to use",
+    )
+    parser.add_argument(
+        "--media",
+        action="store_true",
+        help="Download media attachments to a separate folder",
     )
 
     args = parser.parse_args(argv)

--- a/src/telegram_download_chat/core/downloader.py
+++ b/src/telegram_download_chat/core/downloader.py
@@ -6,11 +6,12 @@ from .auth import AuthMixin
 from .config import ConfigMixin
 from .download import DownloadMixin
 from .entities import EntitiesMixin
+from .media import MediaMixin
 from .messages import MessagesMixin
 
 
 class TelegramChatDownloader(
-    ConfigMixin, AuthMixin, DownloadMixin, EntitiesMixin, MessagesMixin
+    ConfigMixin, AuthMixin, DownloadMixin, EntitiesMixin, MessagesMixin, MediaMixin
 ):
     """Main class for downloading Telegram chat history."""
 

--- a/src/telegram_download_chat/core/media.py
+++ b/src/telegram_download_chat/core/media.py
@@ -1,0 +1,123 @@
+"""Media download functionality for Telegram messages."""
+
+from pathlib import Path
+from typing import Any, List, Optional
+
+from telethon.tl.types import (
+    Document,
+    MessageMediaDocument,
+    MessageMediaPhoto,
+    Photo,
+)
+
+
+class MediaMixin:
+    """Mixin class for downloading media from Telegram messages."""
+
+    def get_filename(self, media: Any) -> Optional[str]:
+        """Returns a filename for the given media object."""
+        if isinstance(media, MessageMediaPhoto):
+            photo = media.photo
+            if isinstance(photo, Photo):
+                return f"{photo.id}.jpg"
+
+        elif isinstance(media, MessageMediaDocument):
+            doc = media.document
+            if isinstance(doc, Document):
+                return f"{doc.id}{self._get_extension_from_mime(doc.mime_type)}"
+
+        return None
+
+    def _get_extension_from_mime(self, mime_type: Optional[str]) -> str:
+        """Derive the file extension from its MIME type."""
+        if not mime_type:
+            return ".bin"
+
+        mime_to_ext = {
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/gif": ".gif",
+            "image/webp": ".webp",
+            "video/mp4": ".mp4",
+            "video/webm": ".webm",
+            "video/quicktime": ".mov",
+            "audio/mpeg": ".mp3",
+            "audio/ogg": ".ogg",
+            "audio/mp4": ".m4a",
+            "audio/x-wav": ".wav",
+            "application/pdf": ".pdf",
+            "application/zip": ".zip",
+            "application/x-rar-compressed": ".rar",
+            "application/x-7z-compressed": ".7z",
+            "text/plain": ".txt",
+            "application/json": ".json",
+            "application/xml": ".xml",
+            "image/tiff": ".tiff",
+            "image/bmp": ".bmp",
+        }
+
+        return mime_to_ext.get(mime_type, ".bin")
+
+    async def download_message_media(
+        self,
+        message: Any,
+        attachments_dir: Path,
+    ) -> None:
+        """Download media from a single message.
+
+        Creates a directory structure:
+            attachments_dir/<message_id>/<filename>
+        """
+        media = getattr(message, "media", None) or (message.get("media") if isinstance(message, dict) else None)
+        if not media:
+            return
+
+        filename = self.get_filename(media)
+        if not filename:
+            return
+
+        message_id = str(getattr(message, "id", None) or (message.get("id") if isinstance(message, dict) else None))
+        if not message_id:
+            return
+
+        try:
+            # Telethon takes care of creating the directory itself
+            download_to = attachments_dir / message_id / filename
+            downloaded_path = await self.client.download_media(
+                message, file=download_to
+            )
+            if downloaded_path:
+                self.logger.debug(
+                    f"Downloaded media for message {message_id}: {downloaded_path}"
+                )
+            else:
+                self.logger.warning(
+                    f"Failed to download media for message {message_id}"
+                )
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to download media for message {message_id}: {e}"
+            )
+
+    async def download_all_media(
+        self,
+        messages: List[Any],
+        attachments_dir: Path,
+    ) -> None:
+        """Download media from all messages that have attachments.
+
+        Returns a dict mapping message_id to media info.
+        """
+        total = len(messages)
+        downloaded = 0
+
+        for i, msg in enumerate(messages):
+            if self._stop_requested:
+                self.logger.info("Stop requested, aborting media download...")
+                return
+
+
+            await self.download_message_media(msg, attachments_dir)
+            downloaded += 1
+
+        self.logger.info(f"Downloaded {downloaded} media files to {attachments_dir}")

--- a/src/telegram_download_chat/core/messages.py
+++ b/src/telegram_download_chat/core/messages.py
@@ -195,12 +195,21 @@ class MessagesMixin:
             except Exception:
                 return None
 
+    def get_attachments_dir(self, output_file: Path) -> Path:
+        """Get the attachments directory path for a given output file.
+
+        Creates a name <output_file_without_extension>_attachments in the same
+        directory as the output file.
+        """
+        return output_file.parent / f"{output_file.stem}_attachments"
+
     async def save_messages(
         self,
         messages,
         output_file: str,
         save_txt: bool = True,
         sort_order: str = "asc",
+        download_media: bool = False,
     ) -> None:
         output_path = Path(output_file)
 
@@ -223,6 +232,11 @@ class MessagesMixin:
             )
             txt_path_relative = get_relative_to_downloads_dir(txt_path)
             self.logger.info(f"Saved {saved} messages to {txt_path_relative}")
+
+        # Download media attachments if requested
+        if download_media:
+            self.logger.info("Downloading media attachments...")
+            await self.download_all_media(messages, self.get_attachments_dir(output_path))
 
         partial = self.get_temp_file_path(output_path)
         if partial.exists() and not self._stop_requested:


### PR DESCRIPTION
This is likely what's requested in #58: I needed the same thing yesterday, and this code worked for me.

There are few caveats, thought:
1. I didn't add it to either GUI or web interface, only the CLI switch;
2. Files are only downloaded when processing data from API and not when messages are read from a JSON file.

The reason for the former is just my lack of interest: I only needed CLI.
The latter is somewhat more complex: in order to be able to do it with minimal effort, I needed Telethon objects which only exist when Telethon gets data from API. When JSON is read, messages are represented as dictionaries and are not converted back into Telethon objects which makes it impossible to make Telethon operate on them (i.e. download attached media), and this kind of refactoring is not something one should dive into without a prior discussion.