### PR TITLE
feat: add MTProto proxy support

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -28,9 +28,10 @@ settings:
   # gui_chat_hint_tooltip: false  # info icon + hover tooltip (off by default)
   # gui_chat_hint_help: true      # collapsible "How to fill this?" block (on)
 
-  # Optional proxy URL for Telegram connections
-  # Supported schemes: socks5, socks4, http, https
+  # Optional proxy URL for Telegram connections.
+  # Supported: socks5, socks4, http, https, tg://proxy and https://t.me/proxy.
   # proxy_url: socks5://user:password@proxy-host:1080
+  # proxy_url: tg://proxy?server=proxy-host&port=443&secret=YOUR_SECRET
 
   # Parallel media download tuning (default on for files above the threshold).
   # Multiple MTProto connections per file dramatically increase per-file

--- a/src/telegram_download_chat/core/auth_utils.py
+++ b/src/telegram_download_chat/core/auth_utils.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Optional
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from telethon import TelegramClient
 from telethon.errors import (
@@ -18,8 +18,11 @@ from telethon.errors import (
     RPCError,
     SessionPasswordNeededError,
 )
+from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
 logger = logging.getLogger(__name__)
+
+MT_PROXY_TYPE = "mtproto"
 
 
 class TelegramAuthError(Exception):
@@ -44,7 +47,7 @@ class TelegramAuth:
             api_id: Telegram API ID
             api_hash: Telegram API hash
             session_path: Path to store the session file
-            proxy_url: Optional proxy URL (e.g. socks5://user:pass@host:port)
+            proxy_url: Optional SOCKS/HTTP URL or Telegram MTProto proxy link
         """
         self.api_id = api_id
         self.api_hash = api_hash
@@ -53,19 +56,23 @@ class TelegramAuth:
         self.client: Optional[TelegramClient] = None
         self._is_authenticated = False
         self.phone_code_hash: Optional[str] = None
+        self._proxy_config: Optional[dict] = None
 
     @staticmethod
     def parse_proxy_url(proxy_url: Optional[str]) -> Optional[dict]:
-        """Parse a proxy URL into Telethon proxy parameters.
+        """Parse and validate proxy input for Telethon.
 
-        Supports socks5, socks4, and http proxy schemes.
+        Supports SOCKS4/SOCKS5/HTTP URLs plus Telegram MTProto proxy links in
+        ``tg://proxy`` and ``https://t.me/proxy`` form.
 
         Args:
-            proxy_url: Proxy URL string (e.g. socks5://user:pass@host:1080)
+            proxy_url: Proxy URL or Telegram proxy link.
 
         Returns:
-            Dict with proxy_type, addr, port, and optionally username/password,
-            or None if proxy_url is empty/None.
+            Validated proxy configuration, or None when no proxy is configured.
+
+        Raises:
+            ValueError: If the proxy input is unsupported or malformed.
         """
         if not proxy_url:
             return None
@@ -76,6 +83,49 @@ class TelegramAuth:
 
         parsed = urlparse(proxy_url)
         scheme = parsed.scheme.lower()
+        hostname = (parsed.hostname or "").lower()
+        path = parsed.path.rstrip("/").lower()
+
+        is_tg_mtproxy = scheme == "tg" and parsed.netloc.lower() == "proxy"
+        is_tme_proxy_path = hostname == "t.me" and path == "/proxy"
+        is_tme_mtproxy = scheme == "https" and is_tme_proxy_path
+
+        if scheme == "http" and is_tme_proxy_path:
+            raise ValueError(
+                "Telegram MTProto proxy links must use https://t.me/proxy."
+            )
+
+        if is_tg_mtproxy or is_tme_mtproxy:
+            query = parse_qs(parsed.query, keep_blank_values=True)
+            server = query.get("server", [""])[0].strip()
+            port_value = query.get("port", [""])[0].strip()
+            secret = query.get("secret", [""])[0].strip()
+
+            if not server:
+                raise ValueError("MTProto proxy link is missing server.")
+            if not port_value:
+                raise ValueError("MTProto proxy link is missing port.")
+
+            try:
+                port = int(port_value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "MTProto proxy port must be an integer between 1 and 65535."
+                ) from exc
+
+            if not 1 <= port <= 65535:
+                raise ValueError(
+                    "MTProto proxy port must be an integer between 1 and 65535."
+                )
+            if not secret:
+                raise ValueError("MTProto proxy link is missing secret.")
+
+            return {
+                "proxy_type": MT_PROXY_TYPE,
+                "addr": server,
+                "port": port,
+                "secret": secret,
+            }
 
         scheme_map = {
             "socks5": SOCKS5,
@@ -88,7 +138,8 @@ class TelegramAuth:
         if proxy_type is None:
             raise ValueError(
                 f"Unsupported proxy scheme: {scheme}. "
-                f"Supported: socks5, socks4, http, https"
+                "Supported: socks5, socks4, http, https, tg://proxy, "
+                "https://t.me/proxy"
             )
 
         if not parsed.hostname:
@@ -110,6 +161,27 @@ class TelegramAuth:
 
         return result
 
+    async def _connect_client(self) -> None:
+        """Connect while preventing MTProto proxy secrets from reaching errors."""
+        if not self.client:
+            return
+
+        try:
+            await self.client.connect()
+        except Exception:
+            if (
+                self._proxy_config
+                and self._proxy_config.get("proxy_type") == MT_PROXY_TYPE
+            ):
+                # Suppress the original exception context. Some transports may
+                # include proxy configuration in low-level error text, so keeping
+                # the exception chain could expose the MTProto secret if a caller
+                # later logs a traceback.
+                raise TelegramAuthError(
+                    "Failed to connect through the configured MTProto proxy."
+                ) from None
+            raise
+
     async def initialize(self) -> None:
         """Initialize the Telegram client."""
         if self.client is None:
@@ -122,15 +194,24 @@ class TelegramAuth:
             }
 
             proxy = self.parse_proxy_url(self.proxy_url)
+            self._proxy_config = proxy
             if proxy:
-                try:
-                    import python_socks  # noqa: F401
-                except ImportError:
-                    raise ImportError(
-                        "Proxy support requires python-socks[asyncio]. "
-                        "Install with: pip install 'python-socks[asyncio]'"
+                if proxy.get("proxy_type") == MT_PROXY_TYPE:
+                    kwargs["connection"] = ConnectionTcpMTProxyRandomizedIntermediate
+                    kwargs["proxy"] = (
+                        proxy["addr"],
+                        proxy["port"],
+                        proxy["secret"],
                     )
-                kwargs["proxy"] = proxy
+                else:
+                    try:
+                        import python_socks  # noqa: F401
+                    except ImportError:
+                        raise ImportError(
+                            "Proxy support requires python-socks[asyncio]. "
+                            "Install with: pip install 'python-socks[asyncio]'"
+                        )
+                    kwargs["proxy"] = proxy
 
             self.client = TelegramClient(
                 self.session_path,
@@ -138,7 +219,7 @@ class TelegramAuth:
                 self.api_hash,
                 **kwargs,
             )
-            await self.client.connect()
+            await self._connect_client()
             self._is_authenticated = await self.client.is_user_authorized()
 
     async def request_code(self, phone: str) -> Optional[str]:
@@ -160,13 +241,19 @@ class TelegramAuth:
 
             if not self.client.is_connected():
                 logger.debug("Client not connected, connecting...")
-                await self.client.connect()
+                await self._connect_client()
 
             logger.debug("Sending code request...")
             result = await self.client.send_code_request(phone)
             self.phone_code_hash = getattr(result, "phone_code_hash", None)
             logger.debug(f"Code request sent successfully: {result}")
             return self.phone_code_hash
+
+        except TelegramAuthError:
+            # Connection errors from _connect_client() are already sanitized.
+            # Re-raise them unchanged instead of sending them through the generic
+            # traceback logger below.
+            raise
 
         except (
             PhoneNumberInvalidError,

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,14 +1,17 @@
 """Tests for proxy URL parsing and TelegramAuth proxy support."""
 
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from telethon.network.connection import ConnectionTcpMTProxyRandomizedIntermediate
 
-from telegram_download_chat.core.auth_utils import TelegramAuth
+from telegram_download_chat.core.auth_utils import TelegramAuth, TelegramAuthError
 
 # Numeric proxy type constants matching PySocks/python-socks/Telethon
 SOCKS5, SOCKS4, HTTP = 2, 1, 3
+MT_SECRET = "dd0123456789abcdef0123456789abcdef"
 
 
 class TestParseProxyUrl:
@@ -65,6 +68,64 @@ class TestParseProxyUrl:
         result = TelegramAuth.parse_proxy_url("http://proxy.example.com")
         assert result["port"] == 8080
 
+    def test_tg_mtproto_proxy(self):
+        result = TelegramAuth.parse_proxy_url(
+            "tg://proxy?server=mtproxy.example.com&port=443&secret=" + MT_SECRET
+        )
+        assert result == {
+            "proxy_type": "mtproto",
+            "addr": "mtproxy.example.com",
+            "port": 443,
+            "secret": MT_SECRET,
+        }
+
+    def test_tme_mtproto_proxy(self):
+        result = TelegramAuth.parse_proxy_url(
+            "https://t.me/proxy?server=1.2.3.4&port=8443&secret=" + MT_SECRET
+        )
+        assert result == {
+            "proxy_type": "mtproto",
+            "addr": "1.2.3.4",
+            "port": 8443,
+            "secret": MT_SECRET,
+        }
+
+    def test_http_tme_mtproto_link_rejected(self):
+        with pytest.raises(ValueError, match="must use https://t.me/proxy"):
+            TelegramAuth.parse_proxy_url(
+                "http://t.me/proxy?server=1.2.3.4&port=443&secret=" + MT_SECRET
+            )
+
+    def test_mtproto_missing_server_raises(self):
+        with pytest.raises(ValueError, match="missing server"):
+            TelegramAuth.parse_proxy_url("tg://proxy?port=443&secret=" + MT_SECRET)
+
+    def test_mtproto_invalid_port_raises(self):
+        with pytest.raises(ValueError, match="port must be an integer"):
+            TelegramAuth.parse_proxy_url(
+                "tg://proxy?server=mtproxy.example.com&port=invalid&secret=" + MT_SECRET
+            )
+
+    @pytest.mark.parametrize("port", ["0", "65536"])
+    def test_mtproto_out_of_range_port_raises(self, port):
+        with pytest.raises(ValueError, match="between 1 and 65535"):
+            TelegramAuth.parse_proxy_url(
+                f"tg://proxy?server=mtproxy.example.com&port={port}&secret=" + MT_SECRET
+            )
+
+    def test_mtproto_missing_secret_raises(self):
+        with pytest.raises(ValueError, match="missing secret"):
+            TelegramAuth.parse_proxy_url(
+                "tg://proxy?server=mtproxy.example.com&port=443"
+            )
+
+    def test_mtproto_error_does_not_include_secret(self):
+        url = "tg://proxy?server=mtproxy.example.com&port=invalid&secret=" + MT_SECRET
+        with pytest.raises(ValueError) as exc_info:
+            TelegramAuth.parse_proxy_url(url)
+
+        assert MT_SECRET not in str(exc_info.value)
+
     def test_unsupported_scheme_raises(self):
         with pytest.raises(ValueError, match="Unsupported proxy scheme"):
             TelegramAuth.parse_proxy_url("ftp://proxy.example.com:21")
@@ -91,6 +152,7 @@ class TestTelegramAuthProxy:
         ) as mock_client_cls:
             mock_client = MagicMock()
             mock_client.connect = AsyncMock()
+            mock_client.is_connected.return_value = False
             mock_client.is_user_authorized = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
@@ -98,6 +160,8 @@ class TestTelegramAuthProxy:
 
             call_kwargs = mock_client_cls.call_args[1]
             assert "proxy" not in call_kwargs
+            assert "connection" not in call_kwargs
+            await auth.close()
 
     @pytest.mark.asyncio
     async def test_initialize_with_proxy(self):
@@ -115,6 +179,7 @@ class TestTelegramAuthProxy:
         ):
             mock_client = MagicMock()
             mock_client.connect = AsyncMock()
+            mock_client.is_connected.return_value = False
             mock_client.is_user_authorized = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
@@ -125,3 +190,91 @@ class TestTelegramAuthProxy:
             assert call_kwargs["proxy"]["proxy_type"] == SOCKS5
             assert call_kwargs["proxy"]["addr"] == "proxy.example.com"
             assert call_kwargs["proxy"]["port"] == 1080
+            assert "connection" not in call_kwargs
+            await auth.close()
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_mtproto_proxy(self):
+        auth = TelegramAuth(
+            api_id=123,
+            api_hash="abc",
+            session_path=Path("/tmp/test"),
+            proxy_url=(
+                "https://t.me/proxy?server=mtproxy.example.com&port=443&secret="
+                + MT_SECRET
+            ),
+        )
+        with patch(
+            "telegram_download_chat.core.auth_utils.TelegramClient"
+        ) as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.connect = AsyncMock()
+            mock_client.is_connected.return_value = False
+            mock_client.is_user_authorized = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await auth.initialize()
+
+            call_kwargs = mock_client_cls.call_args[1]
+            assert (
+                call_kwargs["connection"] is ConnectionTcpMTProxyRandomizedIntermediate
+            )
+            assert call_kwargs["proxy"] == ("mtproxy.example.com", 443, MT_SECRET)
+            await auth.close()
+
+    @pytest.mark.asyncio
+    async def test_mtproto_connect_error_does_not_include_secret(self):
+        auth = TelegramAuth(
+            api_id=123,
+            api_hash="abc",
+            session_path=Path("/tmp/test"),
+            proxy_url=(
+                "tg://proxy?server=mtproxy.example.com&port=443&secret=" + MT_SECRET
+            ),
+        )
+        with patch(
+            "telegram_download_chat.core.auth_utils.TelegramClient"
+        ) as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.connect = AsyncMock(
+                side_effect=RuntimeError("proxy failed with secret " + MT_SECRET)
+            )
+            mock_client.is_connected.return_value = False
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(TelegramAuthError) as exc_info:
+                await auth.initialize()
+
+            assert MT_SECRET not in str(exc_info.value)
+            assert exc_info.value.__cause__ is None
+            assert exc_info.value.__suppress_context__ is True
+            await auth.close()
+
+    @pytest.mark.asyncio
+    async def test_request_code_reconnect_error_does_not_log_secret(self, caplog):
+        auth = TelegramAuth(
+            api_id=123,
+            api_hash="abc",
+            session_path=Path("/tmp/test"),
+            proxy_url=(
+                "tg://proxy?server=mtproxy.example.com&port=443&secret=" + MT_SECRET
+            ),
+        )
+        auth._proxy_config = TelegramAuth.parse_proxy_url(auth.proxy_url)
+
+        mock_client = MagicMock()
+        mock_client.is_connected.return_value = False
+        mock_client.connect = AsyncMock(
+            side_effect=RuntimeError("reconnect failed with secret " + MT_SECRET)
+        )
+        mock_client.send_code_request = AsyncMock()
+        auth.client = mock_client
+
+        caplog.set_level(logging.DEBUG, logger="telegram_download_chat.core.auth_utils")
+        with pytest.raises(TelegramAuthError) as exc_info:
+            await auth.request_code("+10000000000")
+
+        assert MT_SECRET not in str(exc_info.value)
+        assert MT_SECRET not in caplog.text
+        mock_client.send_code_request.assert_not_awaited()
+        await auth.close()


### PR DESCRIPTION
## Summary

Extends the existing `proxy_url` support with Telegram MTProto proxy links while preserving current SOCKS4/SOCKS5/HTTP behavior.

Supported MTProto formats:

- `tg://proxy?server=HOST&port=PORT&secret=SECRET`
- `https://t.me/proxy?server=HOST&port=PORT&secret=SECRET`

## Implementation

- Parse and validate MTProto `server`, `port`, and `secret` in the existing centralized proxy parser.
- Configure Telethon with `ConnectionTcpMTProxyRandomizedIntermediate` and `(host, port, secret)`.
- Keep the existing `python-socks` path unchanged for SOCKS/HTTP proxies.
- Accept the documented HTTPS `t.me/proxy` link form and reject the ambiguous `http://t.me/proxy` form instead of treating it as a regular HTTP proxy.
- Sanitize MTProto connection failures and suppress the original exception context so a low-level transport error cannot expose the proxy secret through a later traceback log.
- Re-raise already-sanitized MTProto reconnect errors from `request_code()` without routing them through the generic traceback logger.
- Document MTProto link formats in `config.example.yml`.

## Tests

Adds coverage for:

- `tg://proxy?...` parsing
- `https://t.me/proxy?...` parsing
- rejection of `http://t.me/proxy?...`
- missing server / invalid port / out-of-range port / missing secret
- existing SOCKS5 behavior
- `connection=` and `proxy=` passed to `TelegramClient`
- absence of MTProto secret from user-facing connection errors
- suppression of the original low-level exception chain
- absence of MTProto secret from reconnect logs during `request_code()`

### Local validation

Windows / Python 3.12.2 validation was run on the upstream-candidate tree now represented by the squashed commit.

- `pytest tests/test_proxy.py -v`: **26 passed**.
- `black src/telegram_download_chat/core/auth_utils.py tests/test_proxy.py --check`: **passed**.
- `isort src/telegram_download_chat/core/auth_utils.py tests/test_proxy.py --check-only`: **passed**.
- Critical `flake8` checks (`E9,F63,F7,F82`) on the changed Python files: **passed**.
- `git diff --check origin/master...HEAD`: **passed**.
- Full `pytest -v`: **471 passed, 2 failed, 9 skipped** on Windows.
- The two full-suite failures appear unrelated to this PR: they are TXT reaction/emoji encoding failures in `tests/test_telegram_download_chat.py` where the expected emoji are read back as mojibake on this Windows environment. Neither the failing tests nor the reaction/TXT export implementation are changed by this PR.

The upstream GitHub Actions workflow runs the pytest suite on Ubuntu for pull requests, so that CI result should be treated as the authoritative cross-platform check.

## Manual validation

The MTProto connection path was manually tested with a real MTProto proxy.

During the initial phone-code authentication test, the `SendCodeRequest` reached Telegram and the server returned a `FloodWaitError` with a wait time of roughly 12 hours. Because of that rate limit, the phone-code login flow could not be completed during the test.

To avoid waiting for the FloodWait to expire, the same MTProto proxy connection was then tested in the fork using Telethon QR authentication.

The manual test successfully completed:

`MTProto proxy -> Telegram connection -> QR authentication -> authorized Telethon session -> chat history download`

A large real-world export was subsequently downloaded through that session, including a chat history containing hundreds of thousands of messages.

QR authentication itself is not part of this PR; it was used only as an alternative authentication method to validate that the MTProto proxy connection works end-to-end.

## AI assistance disclosure

The implementation and tests in this PR were generated with AI assistance (ChatGPT) from contributor-provided requirements. The MTProto behavior was then manually validated end-to-end as described above.

## Scope

This PR intentionally excludes QR login, proxy GUI changes, config redaction work, version bumps, and unrelated changes so the diff stays focused for upstream review.